### PR TITLE
Ensure group-start parameters refresh on plan restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:commands": "node scripts/run-collect-resource-regression.mjs"
   },
   "dependencies": {
     "@types/three": "^0.158.0",

--- a/scripts/run-collect-resource-regression.mjs
+++ b/scripts/run-collect-resource-regression.mjs
@@ -1,0 +1,47 @@
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const outDir = mkdtempSync(join(tmpdir(), 'collect-resource-test-'));
+const outFile = join(outDir, 'collect-resource-test.mjs');
+
+try {
+  await build({
+    entryPoints: ['src/logic/systems/commands/tests/collect-resource-restart.test.ts'],
+    outfile: outFile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    sourcemap: 'inline',
+    alias: {
+      '@logic': 'src/logic',
+      '@core': 'src/logic/core',
+      '@game': 'src/logic/core/game',
+      '@interfaces': 'src/logic/interfaces',
+      '@modules': 'src/logic/modules',
+      '@buildings': 'src/logic/modules/buildings',
+      '@upgrades': 'src/logic/modules/upgrades',
+      '@drones': 'src/logic/modules/drones',
+      '@resources': 'src/logic/modules/resources',
+      '@systems': 'src/logic/systems',
+      '@scene': 'src/logic/systems/scene',
+      '@map': 'src/logic/systems/map',
+      '@commands': 'src/logic/systems/commands',
+      '@modifiers': 'src/logic/systems/modifiers-system',
+      '@save-load': 'src/logic/systems/save-load',
+      '@utils': 'src/logic/utils',
+      '@shared': 'src/logic/shared',
+      '@ui': 'src/ui'
+    }
+  });
+
+  const module = await import(pathToFileURL(outFile).href);
+  if (typeof module.runCollectResourceRestartRegression !== 'function') {
+    throw new Error('runCollectResourceRestartRegression export not found');
+  }
+  module.runCollectResourceRestartRegression();
+} finally {
+  rmSync(outDir, { recursive: true, force: true });
+}

--- a/src/logic/systems/commands/CommandContextStore.ts
+++ b/src/logic/systems/commands/CommandContextStore.ts
@@ -88,5 +88,15 @@ export class CommandContextStore {
     }
     record.context = context;
     record.resolvedCache = context.resolved ? { ...context.resolved } : {};
+    if (!record.pipeline) {
+      return;
+    }
+
+    const resolved = this.resolutionService.resolveParameters(record.pipeline, record.context, 'group-start');
+    record.resolvedCache = mergeResolved(record.resolvedCache, resolved);
+    if (!record.context.resolved) {
+      record.context.resolved = {};
+    }
+    record.context.resolved = mergeResolved(record.context.resolved, resolved);
   }
 }

--- a/src/logic/systems/commands/CommandScheduler.ts
+++ b/src/logic/systems/commands/CommandScheduler.ts
@@ -134,6 +134,7 @@ export class CommandScheduler {
   private restartRuntime(runtime: PlanRuntime): void {
     runtime.instance.resetToInitialState();
     this.contextStore.reset(runtime.instance.id, runtime.instance.getContext());
+    this.contextStore.resolveForTiming(runtime.instance.id, 'group-start');
     this.callbacks.onPlanRestarted?.(runtime);
     this.dispatchNext(runtime);
   }

--- a/src/logic/systems/commands/tests/collect-resource-restart.test.ts
+++ b/src/logic/systems/commands/tests/collect-resource-restart.test.ts
@@ -1,0 +1,175 @@
+// @ts-nocheck
+import { strict as assert } from 'node:assert';
+import { pathToFileURL } from 'node:url';
+import { CommandScheduler } from '../CommandScheduler';
+import { CommandContextStore } from '../CommandContextStore';
+import { ParameterResolutionService } from '../ParameterResolutionService';
+import { COMMAND_GROUPS } from '../db/command-groups-db';
+import { PlanInstance } from '../plans/PlanInstance';
+import { Command, CommandFailureCode, CommandResult } from '../command.types';
+import { CommandGroupContext } from '../command-group.types';
+
+interface RecordedCommand {
+  objectId: string;
+  command: Command;
+}
+
+class TestCommandSystem {
+  public readonly addedCommands: RecordedCommand[] = [];
+
+  addCommand(objectId: string, command: Command): void {
+    this.addedCommands.push({ objectId, command });
+  }
+
+  clearCommandsByGroup(_objectId: string, _groupId: string): void {
+    // No-op for tests
+  }
+}
+
+function createMapLogic() {
+  const droneObject = {
+    id: 'drone-1',
+    coordinates: { x: 0, y: 0, z: 0 },
+    bottomAnchor: 0,
+    data: { storage: {} }
+  };
+  const resourceObject = {
+    id: 'resource-1',
+    coordinates: { x: 10, y: 0, z: 10 },
+    bottomAnchor: 0,
+    data: {}
+  };
+  const storageObject = {
+    id: 'storage-1',
+    coordinates: { x: -5, y: 0, z: -5 },
+    bottomAnchor: 0,
+    data: { isBuilt: true },
+    commandType: ['unload-resources']
+  };
+
+  const objects: Record<string, any> = {
+    [droneObject.id]: droneObject,
+    [resourceObject.id]: resourceObject,
+    [storageObject.id]: storageObject
+  };
+
+  const mapLogic = {
+    scene: {
+      getObjectById(id: string) {
+        return objects[id];
+      },
+      getObjectsByTag(tag: string) {
+        if (tag === 'storage') {
+          return { [storageObject.id]: storageObject };
+        }
+        return {};
+      },
+      getObjectsInRadius() {
+        return [];
+      },
+      getObjectsByTagInRadius() {
+        return [];
+      },
+      pathfinder: {
+        findDockingPointToStatic(_drone: any, target: any) {
+          return {
+            x: target.coordinates.x + 1,
+            y: target.coordinates.y,
+            z: target.coordinates.z + 1
+          };
+        }
+      }
+    },
+    resources: {
+      isUnlocked() {
+        return true;
+      }
+    }
+  };
+
+  return { mapLogic, droneObject, resourceObject };
+}
+
+export function runCollectResourceRestartRegression(): void {
+  const { mapLogic, droneObject, resourceObject } = createMapLogic();
+  const parameterService = new ParameterResolutionService(mapLogic);
+  const contextStore = new CommandContextStore(parameterService);
+  const commandSystem = new TestCommandSystem();
+
+  const callbacks = {
+    onPlanCompleted: () => {
+      // No-op
+    },
+    onPlanFailed: () => {
+      throw new Error('Plan should not fail in regression test');
+    },
+    onPlanRestarted: () => {
+      // No-op
+    }
+  };
+
+  const scheduler = new CommandScheduler(commandSystem as any, contextStore, callbacks);
+
+  const group = COMMAND_GROUPS.find(g => g.id === 'collect-resource');
+  if (!group) {
+    throw new Error('collect-resource group not found');
+  }
+
+  const context: CommandGroupContext = {
+    objectId: droneObject.id,
+    targets: {
+      resource: resourceObject.id
+    },
+    parameters: {}
+  };
+
+  const planInstance = new PlanInstance({
+    id: 'runtime-1',
+    groupId: group.id,
+    objectId: droneObject.id,
+    root: group.plan,
+    context,
+    store: contextStore
+  });
+
+  scheduler.registerPlan(planInstance, group, droneObject.id);
+
+  assert.strictEqual(commandSystem.addedCommands.length, 1, 'Expected initial move-to command');
+  const initialMoveCommand = commandSystem.addedCommands[0].command;
+  assert.strictEqual(initialMoveCommand.type, 'move-to');
+  assert.deepStrictEqual(initialMoveCommand.position, { x: 11, y: 0, z: 11 });
+
+  scheduler.onCommandCompleted(droneObject.id, initialMoveCommand);
+
+  assert.strictEqual(commandSystem.addedCommands.length, 2, 'Expected collect-resource command after move completion');
+  const collectCommand = commandSystem.addedCommands[1].command;
+  assert.strictEqual(collectCommand.type, 'collect-resource');
+
+  resourceObject.coordinates.x = 30;
+  resourceObject.coordinates.y = 0;
+  resourceObject.coordinates.z = 5;
+
+  const failureResult: CommandResult = {
+    success: false,
+    message: 'Resource missing',
+    code: CommandFailureCode.RESOURCE_NOT_FOUND
+  };
+
+  scheduler.onCommandFailed(droneObject.id, collectCommand, failureResult);
+
+  assert.strictEqual(commandSystem.addedCommands.length, 3, 'Expected move-to command after restart');
+  const restartedMoveCommand = commandSystem.addedCommands[2].command;
+  assert.strictEqual(restartedMoveCommand.type, 'move-to');
+  assert.deepStrictEqual(restartedMoveCommand.position, { x: 31, y: 0, z: 6 });
+
+  const resolvedPosition = contextStore.getResolvedValue<any>(planInstance.id, 'resourcePosition');
+  assert.ok(resolvedPosition, 'Resolved resource position should be available after restart');
+  assert.strictEqual(resolvedPosition.x, 31);
+  assert.strictEqual(resolvedPosition.z, 6);
+
+  console.log('✅ collect-resource restart regression passed');
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  runCollectResourceRestartRegression();
+}


### PR DESCRIPTION
## Summary
- rerun group-start parameter resolution when contexts are reset to restore resolved caches
- refresh group-start parameters before dispatching commands on plan restarts
- add a collect-resource restart regression simulation and script hook to run it

## Testing
- npm run test:commands

------
https://chatgpt.com/codex/tasks/task_e_68cf0a0793a883208b7de35bd01eb11b