### PR TITLE
Integrate auto group scheduling and fix unload completion

### DIFF
--- a/src/logic/systems/commands/AutoGroupMonitor.ts
+++ b/src/logic/systems/commands/AutoGroupMonitor.ts
@@ -1,4 +1,3 @@
-import { Command } from './command.types';
 import { getAutoExecuteGroups } from './db/command-groups-db';
 
 export class AutoGroupMonitor {
@@ -57,6 +56,11 @@ export class AutoGroupMonitor {
     private shouldExecuteAutoGroup(group: any, object: any): boolean {
         if (!group.autoExecute) return false;
         
+        const activeGroupState = this.mapLogic.commandGroupSystem.getGroupState(object.id, group.id);
+        if (activeGroupState && activeGroupState.status === 'active') {
+            return false;
+        }
+
         // Перевіряємо чи перша команда не належить цій групі
         const commandQueue = this.mapLogic.commandSystem.getCommandQueue(object.id);
         if (commandQueue && commandQueue.getLength() > 0) {
@@ -88,88 +92,17 @@ export class AutoGroupMonitor {
      * Виконує автоматичну групу команд
      */
     private executeAutoGroup(objectId: string, group: any): void {
-        // Отримуємо поточну чергу команд
-        const commandQueue = this.mapLogic.commandSystem.getCommandQueue(objectId);
-        
-        if (!commandQueue) {
-            console.warn(`[Auto-command] No command queue found for ${objectId}`);
-            return;
-        }
-
-        // Зберігаємо ВСІ поточні команди (включаючи executing)
-        let currentCommands: Command[] = commandQueue.getAllCommands();
-        let firstCommand: any = null
-
-        let interruptedGroupContext: any = null;
-        if (currentCommands.length > 0) {
-            firstCommand = currentCommands[0];
-            if (firstCommand.groupId) {
-                // Зберігаємо контекст перерваної групи
-                const groupState = this.mapLogic.commandGroupSystem.getGroupState(objectId, firstCommand.groupId);
-                if (groupState) {
-                    interruptedGroupContext = groupState.context;
-                }
-                
-                // Видаляємо всі команди цієї групи з currentCommands
-                currentCommands = currentCommands.filter(cmd => cmd.groupId !== firstCommand.groupId);
-            }
-        }
-        
-        // Очищаємо чергу
-        commandQueue.clearAll();
-        
-        // Додаємо автоматичну групу БЕЗ loop
         const autoGroupContext = {
             objectId,
             targets: {},
-            parameters: {}
+            parameters: {},
+            resolved: {}
         };
-        /*
-        // Створюємо команди з групи
-        const autoCommands = group.tasksPipeline(autoGroupContext);
-        
-        // Розв'язуємо параметри для автоматичної групи
-        if (group.resolveParametersPipeline) {
-            const resolvedParameters = this.mapLogic.commandGroupSystem.parameterResolutionService.resolveParameters(
-                group.resolveParametersPipeline,
-                autoGroupContext,
-                'group-start' // Розв'язуємо всі параметри на початку групи
-            );
-            
-            // Параметри розв'язані
-            
-            // Застосовуємо розв'язані параметри до команд
-            for (const command of autoCommands) {
-                this.applyResolvedParameters(command, resolvedParameters);
-            }
-        }
-        
-        // Додаємо команди з групи в початок
-        for (const command of autoCommands) {
-            // Встановлюємо groupId та вимикаємо loop
-            command.groupId = group.id;
-            command.status = 'pending';
-            command.createdAt = Date.now();
-            
-            // Додаємо команду
-            this.mapLogic.commandSystem.addCommand(objectId, command);
-        } */
 
-        // 🔥 КРИТИЧНО: Створюємо стан групи щоб вона зберігалася/завантажувалася
-        this.mapLogic.commandGroupSystem.addCommandGroup(objectId, group.id, autoGroupContext);
-        
-        if (interruptedGroupContext && firstCommand) {
-            this.mapLogic.commandGroupSystem.addCommandGroup(objectId, firstCommand.groupId, interruptedGroupContext);
+        const started = this.mapLogic.commandGroupSystem.addCommandGroup(objectId, group.id, autoGroupContext);
+        if (!started) {
+            console.warn(`[Auto-command] Failed to start auto group ${group.id} for ${objectId}`);
         }
-        
-        // Додаємо назад поточні команди
-        for (const command of currentCommands) {
-            command.status = 'pending'; // Скидаємо статус
-            this.mapLogic.commandSystem.addCommand(objectId, command);
-        }
-        
-        
-        // Авто-група вставлена
     }
 
 }

--- a/src/logic/systems/commands/CommandScheduler.ts
+++ b/src/logic/systems/commands/CommandScheduler.ts
@@ -48,8 +48,19 @@ export class CommandScheduler {
       groupKey: `${objectId}-${group.id}`
     };
 
-    const queue = this.runtimeQueuesByObject.get(objectId) ?? [];
-    queue.push(runtime);
+    let queue = this.runtimeQueuesByObject.get(objectId);
+    if (!queue) {
+      queue = [];
+    }
+
+    const shouldInterrupt = group.autoExecute?.priority === 'interrupt';
+    if (shouldInterrupt && queue.length > 0) {
+      const activeRuntime = queue[0];
+      this.pauseRuntime(activeRuntime);
+      queue.unshift(runtime);
+    } else {
+      queue.push(runtime);
+    }
     this.runtimeQueuesByObject.set(objectId, queue);
 
     this.runtimeByInstanceId.set(instance.id, runtime);
@@ -57,7 +68,7 @@ export class CommandScheduler {
 
     this.contextStore.register(instance.id, instance.getContext(), group.resolveParametersPipeline);
 
-    if (queue.length === 1 && !this.activeCommandByObject.has(objectId)) {
+    if (queue[0] === runtime && !this.activeCommandByObject.has(objectId)) {
       this.dispatchNext(runtime);
     }
   }
@@ -205,5 +216,21 @@ export class CommandScheduler {
       }
       command.parameters[field] = value;
     }
+  }
+
+  private pauseRuntime(runtime: PlanRuntime): void {
+    const activeCommandId = this.activeCommandByObject.get(runtime.objectId);
+    if (!activeCommandId) {
+      return;
+    }
+
+    const pending = this.pendingCommandById.get(activeCommandId);
+    if (pending && pending.runtime === runtime) {
+      this.pendingCommandById.delete(activeCommandId);
+      runtime.instance.markCommandFailed(activeCommandId);
+    }
+
+    this.activeCommandByObject.delete(runtime.objectId);
+    this.commandSystem.clearCommandsByGroup(runtime.objectId, runtime.group.id);
   }
 }

--- a/src/logic/systems/commands/executors/UnloadResourcesExecutor.ts
+++ b/src/logic/systems/commands/executors/UnloadResourcesExecutor.ts
@@ -16,6 +16,8 @@ import {
 
 type PlannedUnload = { resourceId: string; amount: number };
 
+const EPSILON = 1e-8;
+
 export class UnloadResourcesExecutor extends CommandExecutor {
     private unloadProgress: number = 0;
     private lastUnloadTime: number = 0;
@@ -74,7 +76,7 @@ export class UnloadResourcesExecutor extends CommandExecutor {
         const resourcesToUnload = this.command.parameters?.resourcesToUnload as Record<string, number> | undefined;
 
         const { plan, totalRequested } = this.buildUnloadPlan(storage, resourcesToUnload, unloadBudget);
-        if (totalRequested <= 0) {
+        if (totalRequested <= EPSILON) {
             this.lastUnloadTime = currentTime;
             this.unloadProgress = calculateUnloadProgress(storage, getDroneCapacity(object));
             return {
@@ -116,8 +118,9 @@ export class UnloadResourcesExecutor extends CommandExecutor {
 
         const storage = ensureDroneStorage(object);
         const resourcesToUnload = this.command.parameters?.resourcesToUnload as Record<string, number> | undefined;
+        const remainingPlan = this.buildUnloadPlan(storage, resourcesToUnload, Number.POSITIVE_INFINITY);
 
-        if (!this.hasResourcesToUnload(object)) {
+        if (remainingPlan.totalRequested <= EPSILON) {
             return true;
         }
 
@@ -132,9 +135,8 @@ export class UnloadResourcesExecutor extends CommandExecutor {
         }
 
         if (target.tags?.includes('storage') && target.data?.isBuilt) {
-            const plan = this.buildUnloadPlan(storage, resourcesToUnload, Number.POSITIVE_INFINITY);
-            const canFit = plan.plan.some(item => getGlobalFreeCapacity(this.context, item.resourceId) > 0);
-            if (!canFit && plan.plan.length > 0) {
+            const canFit = remainingPlan.plan.some(item => getGlobalFreeCapacity(this.context, item.resourceId) > EPSILON);
+            if (!canFit && remainingPlan.plan.length > 0) {
                 return true;
             }
         } else if (target.tags?.includes('road')) {
@@ -159,7 +161,7 @@ export class UnloadResourcesExecutor extends CommandExecutor {
         const storage = ensureDroneStorage(object);
         const resourcesToUnload = this.command.parameters?.resourcesToUnload as Record<string, number> | undefined;
         const { totalRequested } = this.buildUnloadPlan(storage, resourcesToUnload, Number.POSITIVE_INFINITY);
-        return totalRequested > 0;
+        return totalRequested > EPSILON;
     }
 
     /**
@@ -212,20 +214,20 @@ export class UnloadResourcesExecutor extends CommandExecutor {
         let remaining = maxAmount;
 
         for (const [resourceId, amount] of Object.entries(storage)) {
-            if (remaining <= 0) break;
-            if (amount <= 0) continue;
+            if (remaining <= EPSILON) break;
+            if (amount <= EPSILON) continue;
 
             let allowed = amount;
             if (filter) {
                 const desired = Number(filter[resourceId]) || 0;
-                if (desired <= 0) {
+                if (desired <= EPSILON) {
                     continue;
                 }
                 allowed = Math.min(allowed, desired);
             }
 
             const toUnload = Math.min(allowed, remaining);
-            if (toUnload <= 0) continue;
+            if (toUnload <= EPSILON) continue;
 
             plan.push({ resourceId, amount: toUnload });
             remaining -= toUnload;
@@ -255,7 +257,7 @@ export class UnloadResourcesExecutor extends CommandExecutor {
     }
 
     private depositPlannedResource(object: any, target: any, resourceId: string, amount: number): number {
-        if (amount <= 0) {
+        if (amount <= EPSILON) {
             return 0;
         }
 


### PR DESCRIPTION
## Summary
- allow the command scheduler to interrupt active plans for auto-execute groups and resume after charging
- simplify the auto group monitor to rely on scheduler-managed group state instead of manual queue manipulation
- prevent the unload executor from looping when a drone runs out of resources by using epsilon-aware completion checks

## Testing
- npm run test:commands

------
https://chatgpt.com/codex/tasks/task_e_68cf9f3f073083208b4cb8f97904768e