### PR TITLE
Refactor HUD management for building and road renderers

### DIFF
--- a/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
@@ -1,14 +1,17 @@
 import * as THREE from 'three'
 import { TSceneObject } from '@logic/systems/scene/scene.types'
+import { HudRegistry } from './hud/HudRegistry'
 
 export abstract class BaseRenderer {
     protected scene: THREE.Scene;
     protected renderer?: THREE.WebGLRenderer;
     protected meshes: Map<string, THREE.Object3D> = new Map();
+    protected hudRegistry: HudRegistry;
 
     constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
         this.scene = scene;
         this.renderer = renderer;
+        this.hudRegistry = new HudRegistry(scene);
     }
 
     abstract render(object: TSceneObject): THREE.Object3D;
@@ -34,6 +37,7 @@ export abstract class BaseRenderer {
     remove(id: string): void {
         const mesh = this.meshes.get(id);
         if (mesh) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
             this.meshes.delete(id);
         }
@@ -55,12 +59,12 @@ export abstract class BaseRenderer {
     // Очищення ресурсів (важливо для HMR!)
     // -------------------------
     public dispose(): void {
-        // Очищаємо всі меші з сцени
         for (const [_id, mesh] of this.meshes) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
         }
-        
-        // Очищаємо Map
+
         this.meshes.clear();
+        this.hudRegistry.dispose();
     }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -170,7 +170,7 @@ export class BuildingRenderer extends BaseRenderer {
       const baseParentScale = this.getBaseParentScale(container);
       const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
       const title = config?.name ? `${config.name}` : (object.id || 'building');
-      this.attachOrUpdateCombinedHUD(container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
+      this.attachOrUpdateCombinedHUD(object.id, container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
       (container as any).userData.constructionBarY = HUD_WORLD_Y_OFFSET_FALLBACK;
     } else {
       // Storage HUD via combined HUD without progress bar
@@ -182,7 +182,7 @@ export class BuildingRenderer extends BaseRenderer {
           const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
           const resInfo = this.storageToResourceInfo(storageInfo);
           const title = config?.name ? `${config.name}` : (object.id || 'building');
-          this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
+          this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
         }
       } else {
         this.removeHUD(container);
@@ -242,6 +242,7 @@ export class BuildingRenderer extends BaseRenderer {
         const baseParentScale = this.getBaseParentScale(container);
         const resourceInfo = this.getBuildingResourceInfo(buildingType, data?.resourcesCollected || {});
         this.attachOrUpdateCombinedHUD(
+          object.id,
           container,
           constructionProgress,
           resourceInfo,
@@ -260,7 +261,7 @@ export class BuildingRenderer extends BaseRenderer {
             const baseParentScale = this.getBaseParentScale(container);
             const resInfo = this.storageToResourceInfo(storageInfo);
             const title = config?.name ? `${config.name}` : (object.id || 'building');
-            this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(container);
@@ -284,6 +285,7 @@ export class BuildingRenderer extends BaseRenderer {
 
   // ---------- Combined HUD ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: ResourceInfo,
@@ -375,9 +377,7 @@ export class BuildingRenderer extends BaseRenderer {
         hud!.scale.set(final, final, final);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -403,11 +403,7 @@ export class BuildingRenderer extends BaseRenderer {
   }
 
   private removeHUD(anchor: THREE.Object3D) {
-    const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    if (hud) {
-      this.scene.remove(hud);
-      (anchor as any).userData.combinedHUD = undefined;
-    }
+    this.hudRegistry.detachFromAnchor(anchor);
   }
 
   // ---------- Canvas builder ----------
@@ -800,7 +796,7 @@ export class BuildingRenderer extends BaseRenderer {
         (anchor as any).userData.constructionBarY = storedBaseY;
         (anchor as any).userData.hudYOffset = extraY;
       } else {
-        this.attachOrUpdateCombinedHUD(anchor, p, info, barY, baseParentScale);
+        this.attachOrUpdateCombinedHUD(object.id, anchor, p, info, barY, baseParentScale);
       }
     } else {
       // Built building: render storage HUD if internal storage present
@@ -849,7 +845,7 @@ export class BuildingRenderer extends BaseRenderer {
             (anchor as any).userData.constructionBarY = storedBaseY;
             (anchor as any).userData.hudYOffset = extraY;
           } else {
-            this.attachOrUpdateCombinedHUD(anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(anchor);
@@ -870,16 +866,9 @@ export class BuildingRenderer extends BaseRenderer {
   public dispose(): void {
     this.geometry.dispose();
     this.material.dispose();
-
-    this.meshes.forEach((mesh) => {
-      const hud = (mesh as any).userData?.combinedHUD as THREE.Group | undefined;
-      if (hud) this.scene.remove(hud);
-    });
-
-    this.meshes.forEach((mesh) => this.scene.remove(mesh));
-    this.meshes.clear();
-
     this.modelCache.clear();
+
+    super.dispose();
   }
 
   // ========== Storage HUD Methods ==========

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
@@ -136,7 +136,7 @@ export class RoadRenderer extends BaseRenderer {
         }
         hudAnchor.position.copy(head);
         const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-        this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
+        this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
       } else {
         console.log(`[RoadRenderer.render] Not showing HUD for road ${object.id} - all segments completed`);
       }
@@ -268,7 +268,7 @@ export class RoadRenderer extends BaseRenderer {
           if (!hudAnchor) { hudAnchor = new THREE.Object3D(); hudAnchor.name = 'hudAnchor'; roadGroup.add(hudAnchor); }
           hudAnchor.position.copy(head);
           const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-          this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
+          this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
         } else {
           console.log(`[RoadRenderer.update] Removing HUD for road ${object.id} - all segments completed`);
           const hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
@@ -348,7 +348,8 @@ export class RoadRenderer extends BaseRenderer {
   public dispose(): void {
     super.dispose();
     this.roadSegments.clear();
-    
+    this.lastSegmentStates.clear();
+
     // Очищаємо матеріали
     if (this.roadMaterial) {
       this.roadMaterial.dispose();
@@ -360,6 +361,7 @@ export class RoadRenderer extends BaseRenderer {
 
   // ---------- Combined HUD (mirrors BuildingRenderer) ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; },
@@ -421,9 +423,7 @@ export class RoadRenderer extends BaseRenderer {
         hud!.scale.set(final, final, final);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -440,34 +440,12 @@ export class RoadRenderer extends BaseRenderer {
   private removeHUD(anchor: THREE.Object3D): void {
     const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
     console.log(`[RoadRenderer.removeHUD] Anchor:`, anchor.name, `HUD found:`, !!hud);
-    if (hud) { 
-      // Видаляємо HUD зі сцени
-      this.scene.remove(hud);
-      
-      // Також робимо невидимим на всякий випадок
-      hud.visible = false;
-      
-      // Очищаємо всі дочірні об'єкти HUD
-      hud.clear();
-      
-      // Видаляємо матеріали та геометрії
-      hud.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
-          if (child.geometry) child.geometry.dispose();
-          if (child.material) {
-            if (Array.isArray(child.material)) {
-              child.material.forEach(mat => mat.dispose());
-            } else {
-              child.material.dispose();
-            }
-          }
-        }
-      });
-      
-      // Очищаємо посилання
-      (anchor as any).userData.combinedHUD = undefined;
-      console.log(`[RoadRenderer.removeHUD] HUD removed from scene and disposed`);
+    if (!hud) {
+      return;
     }
+
+    this.hudRegistry.detachFromAnchor(anchor);
+    console.log(`[RoadRenderer.removeHUD] HUD removed from scene and disposed`);
   }
 
   

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+
+type HudSet = Set<THREE.Object3D>;
+
+type HudUserData = {
+  combinedHUD?: THREE.Object3D;
+  __hudOwnerId?: string;
+} & THREE.Object3D['userData'];
+
+export class HudRegistry {
+  private readonly scene: THREE.Scene;
+  private readonly registry = new Map<string, HudSet>();
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+  }
+
+  public register(ownerId: string, anchor: THREE.Object3D, hud: THREE.Object3D): void {
+    const set = this.ensureSet(ownerId);
+    set.add(hud);
+
+    if (hud.parent !== this.scene) {
+      this.scene.add(hud);
+    }
+
+    const data = this.ensureUserData(anchor) as HudUserData;
+    data.__hudOwnerId = ownerId;
+    data.combinedHUD = hud;
+  }
+
+  public detachFromAnchor(anchor: THREE.Object3D): void {
+    const data = anchor.userData as HudUserData | undefined;
+    if (!data) return;
+
+    const hud = data.combinedHUD;
+    if (!hud) return;
+
+    const ownerId = data.__hudOwnerId;
+    this.detach(ownerId, hud);
+
+    delete data.combinedHUD;
+    if (ownerId) delete data.__hudOwnerId;
+  }
+
+  public detachAll(ownerId: string): void {
+    const set = this.registry.get(ownerId);
+    if (!set) return;
+
+    for (const hud of Array.from(set)) {
+      this.disposeHud(hud);
+      set.delete(hud);
+    }
+
+    this.registry.delete(ownerId);
+  }
+
+  public detachFromObjectGraph(root: THREE.Object3D): void {
+    root.traverse((node) => {
+      this.detachFromAnchor(node);
+    });
+  }
+
+  public dispose(): void {
+    for (const ownerId of Array.from(this.registry.keys())) {
+      this.detachAll(ownerId);
+    }
+    this.registry.clear();
+  }
+
+  private detach(ownerId: string | undefined, hud: THREE.Object3D): void {
+    if (ownerId) {
+      const set = this.registry.get(ownerId);
+      if (set && set.delete(hud) && set.size === 0) {
+        this.registry.delete(ownerId);
+      }
+    } else {
+      this.detachBySearch(hud);
+    }
+
+    this.disposeHud(hud);
+  }
+
+  private detachBySearch(hud: THREE.Object3D): void {
+    for (const [id, set] of this.registry.entries()) {
+      if (set.delete(hud)) {
+        if (set.size === 0) {
+          this.registry.delete(id);
+        }
+        break;
+      }
+    }
+  }
+
+  private disposeHud(hud: THREE.Object3D): void {
+    this.scene.remove(hud);
+    hud.removeFromParent();
+
+    hud.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) {
+        const mesh = child as THREE.Mesh;
+        mesh.geometry?.dispose();
+        this.disposeMaterial(mesh.material);
+      }
+    });
+
+    hud.clear();
+  }
+
+  private disposeMaterial(material: THREE.Material | THREE.Material[] | undefined): void {
+    if (!material) return;
+
+    if (Array.isArray(material)) {
+      material.forEach((mat) => this.disposeMaterial(mat));
+      return;
+    }
+
+    const mat = material as THREE.Material & { map?: THREE.Texture };
+    if (mat.map) {
+      mat.map.dispose?.();
+    }
+
+    mat.dispose?.();
+  }
+
+  private ensureSet(ownerId: string): HudSet {
+    let set = this.registry.get(ownerId);
+    if (!set) {
+      set = new Set();
+      this.registry.set(ownerId, set);
+    }
+    return set;
+  }
+
+  private ensureUserData(anchor: THREE.Object3D): THREE.Object3D['userData'] {
+    if (!anchor.userData) {
+      anchor.userData = {};
+    }
+    return anchor.userData;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared HUD registry that tracks billboard groups per object and disposes them when anchors go away
- hook the base renderer into the registry so removing objects or disposing a renderer also tears down any HUDs
- update the building and road renderers to register/remove their HUDs through the registry, fixing stale HUD leftovers when construction completes

## Testing
- npm run build *(fails: repository currently has pre-existing TypeScript errors outside of these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6bddd5883208904aa039ea71b0a