### PR TITLE
Improve HUD stability and road progress updates

### DIFF
--- a/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
@@ -1,14 +1,17 @@
 import * as THREE from 'three'
 import { TSceneObject } from '@logic/systems/scene/scene.types'
+import { HudRegistry } from './hud/HudRegistry'
 
 export abstract class BaseRenderer {
     protected scene: THREE.Scene;
     protected renderer?: THREE.WebGLRenderer;
     protected meshes: Map<string, THREE.Object3D> = new Map();
+    protected hudRegistry: HudRegistry;
 
     constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
         this.scene = scene;
         this.renderer = renderer;
+        this.hudRegistry = new HudRegistry(scene);
     }
 
     abstract render(object: TSceneObject): THREE.Object3D;
@@ -34,6 +37,7 @@ export abstract class BaseRenderer {
     remove(id: string): void {
         const mesh = this.meshes.get(id);
         if (mesh) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
             this.meshes.delete(id);
         }
@@ -55,12 +59,12 @@ export abstract class BaseRenderer {
     // Очищення ресурсів (важливо для HMR!)
     // -------------------------
     public dispose(): void {
-        // Очищаємо всі меші з сцени
         for (const [_id, mesh] of this.meshes) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
         }
-        
-        // Очищаємо Map
+
         this.meshes.clear();
+        this.hudRegistry.dispose();
     }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -170,7 +170,7 @@ export class BuildingRenderer extends BaseRenderer {
       const baseParentScale = this.getBaseParentScale(container);
       const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
       const title = config?.name ? `${config.name}` : (object.id || 'building');
-      this.attachOrUpdateCombinedHUD(container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
+      this.attachOrUpdateCombinedHUD(object.id, container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
       (container as any).userData.constructionBarY = HUD_WORLD_Y_OFFSET_FALLBACK;
     } else {
       // Storage HUD via combined HUD without progress bar
@@ -182,7 +182,7 @@ export class BuildingRenderer extends BaseRenderer {
           const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
           const resInfo = this.storageToResourceInfo(storageInfo);
           const title = config?.name ? `${config.name}` : (object.id || 'building');
-          this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
+          this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
         }
       } else {
         this.removeHUD(container);
@@ -242,6 +242,7 @@ export class BuildingRenderer extends BaseRenderer {
         const baseParentScale = this.getBaseParentScale(container);
         const resourceInfo = this.getBuildingResourceInfo(buildingType, data?.resourcesCollected || {});
         this.attachOrUpdateCombinedHUD(
+          object.id,
           container,
           constructionProgress,
           resourceInfo,
@@ -260,7 +261,7 @@ export class BuildingRenderer extends BaseRenderer {
             const baseParentScale = this.getBaseParentScale(container);
             const resInfo = this.storageToResourceInfo(storageInfo);
             const title = config?.name ? `${config.name}` : (object.id || 'building');
-            this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(container);
@@ -284,6 +285,7 @@ export class BuildingRenderer extends BaseRenderer {
 
   // ---------- Combined HUD ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: ResourceInfo,
@@ -373,11 +375,10 @@ export class BuildingRenderer extends BaseRenderer {
           final = Math.min(final, pxScale);
         }
         hud!.scale.set(final, final, final);
+        hud!.updateMatrixWorld(true);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -403,11 +404,7 @@ export class BuildingRenderer extends BaseRenderer {
   }
 
   private removeHUD(anchor: THREE.Object3D) {
-    const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    if (hud) {
-      this.scene.remove(hud);
-      (anchor as any).userData.combinedHUD = undefined;
-    }
+    this.hudRegistry.detachFromAnchor(anchor);
   }
 
   // ---------- Canvas builder ----------
@@ -800,7 +797,7 @@ export class BuildingRenderer extends BaseRenderer {
         (anchor as any).userData.constructionBarY = storedBaseY;
         (anchor as any).userData.hudYOffset = extraY;
       } else {
-        this.attachOrUpdateCombinedHUD(anchor, p, info, barY, baseParentScale);
+        this.attachOrUpdateCombinedHUD(object.id, anchor, p, info, barY, baseParentScale);
       }
     } else {
       // Built building: render storage HUD if internal storage present
@@ -849,7 +846,7 @@ export class BuildingRenderer extends BaseRenderer {
             (anchor as any).userData.constructionBarY = storedBaseY;
             (anchor as any).userData.hudYOffset = extraY;
           } else {
-            this.attachOrUpdateCombinedHUD(anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(anchor);
@@ -870,16 +867,9 @@ export class BuildingRenderer extends BaseRenderer {
   public dispose(): void {
     this.geometry.dispose();
     this.material.dispose();
-
-    this.meshes.forEach((mesh) => {
-      const hud = (mesh as any).userData?.combinedHUD as THREE.Group | undefined;
-      if (hud) this.scene.remove(hud);
-    });
-
-    this.meshes.forEach((mesh) => this.scene.remove(mesh));
-    this.meshes.clear();
-
     this.modelCache.clear();
+
+    super.dispose();
   }
 
   // ========== Storage HUD Methods ==========

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
@@ -11,6 +11,15 @@ interface RoadSegment {
   width: number;
 }
 
+interface RoadHudInfo {
+  required: Record<string, number>;
+  collected: Record<string, number>;
+  missing: Record<string, number>;
+  progress: number;
+  segmentsBuilt: number;
+  segmentsTotal: number;
+}
+
 export class RoadRenderer extends BaseRenderer {
   private roadMaterial: THREE.Material;
   private plannedRoadMaterial: THREE.Material;
@@ -21,6 +30,9 @@ export class RoadRenderer extends BaseRenderer {
   private cachedCanvasTexture: THREE.CanvasTexture | null = null;
   private lastAspect = 1;
   private lastContentHeightWorld = 1;
+  private readonly CANVAS_UPDATE_THROTTLE_MS = 200;
+  private lastCanvasUpdate = 0;
+  private hudSignatures: Map<string, string> = new Map();
 
   // For roads use full canvas width to avoid left cropping
   private readonly HUD_SAFE_FRACTION = 1.0;
@@ -109,7 +121,6 @@ export class RoadRenderer extends BaseRenderer {
       const parentState = segmentStates[parentIdx];
       // Якщо вся дорога збудована (object.data.built) - всі сегменти вважаються збудованими
       const isSegmentPlanned = (isPlanned || !object.data?.built) && parentState?.buildingState !== 'completed';
-      console.log(`Road: ${object.id}`, isPlanned, object.data?.built, parentState, isSegmentPlanned);
       const segmentMesh = this.createSegmentMesh(segment, `${object.id}_segment_${index}`, isSegmentPlanned);
       roadGroup.add(segmentMesh);
     });
@@ -119,27 +130,28 @@ export class RoadRenderer extends BaseRenderer {
 
     this.addMesh(object.id, roadGroup);
 
-    // HUD над центром ПЕРШОГО сегмента
-    if (this.uiLogicBridge) {
-      const info = this.getRoadResourceInfo(object.id);
-      if (info && info.segmentsBuilt < info.segmentsTotal) {
-        // Обчислюємо anchor з першого сегмента
-        const first = segments[0];
-        const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
-        const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
-        const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
-        let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-        if (!hudAnchor) {
-          hudAnchor = new THREE.Object3D();
-          hudAnchor.name = 'hudAnchor';
-          roadGroup.add(hudAnchor);
-        }
-        hudAnchor.position.copy(head);
-        const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-        this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
-      } else {
-        console.log(`[RoadRenderer.render] Not showing HUD for road ${object.id} - all segments completed`);
+    const info = this.buildRoadResourceInfo(object);
+    const isFullyBuilt = !!object.data?.built;
+
+    if (!isFullyBuilt && info && info.segmentsTotal > 0 && info.segmentsBuilt < info.segmentsTotal) {
+      const first = segments[0];
+      const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
+      const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
+      const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
+      let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
+      if (!hudAnchor) {
+        hudAnchor = new THREE.Object3D();
+        hudAnchor.name = 'hudAnchor';
+        roadGroup.add(hudAnchor);
       }
+      hudAnchor.position.copy(head);
+      const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
+      const signature = this.createHudSignature(info);
+      this.hudSignatures.set(object.id, signature);
+      this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
+    } else {
+      this.hudRegistry.detachAll(object.id);
+      this.hudSignatures.delete(object.id);
     }
     return roadGroup;
   }
@@ -200,8 +212,6 @@ export class RoadRenderer extends BaseRenderer {
     const mesh = new THREE.Mesh(geometry, material);
     mesh.name = name;
 
-    console.log('createSegmentMesh called: ', isPlanned);
-    
     return mesh;
   }
 
@@ -233,51 +243,67 @@ export class RoadRenderer extends BaseRenderer {
 
 
   update(object: TSceneObject): void {
-    // Базове оновлення позиції від BaseRenderer
     super.update(object);
-    
-    // Додаткова логіка оновлення дороги якщо потрібно
-    const roadGroup = this.meshes.get(object.id);
-    if (roadGroup && object.data?.roadSegments) {
-      // Якщо сегменти змінилися - перебудовуємо дорогу
-      const currentSegments = this.roadSegments.get(object.id);
-      const newSegments = object.data.roadSegments;
-      const segmentStates = object.data?.segmentStates || [];
-        if (!this.segmentsEqual(currentSegments, newSegments) || this.segmentStatesChanged(object.id, segmentStates)) {
-          this.remove(object.id);
-          this.render(object);
-          console.log('Re-render: ', object, !!this.uiLogicBridge);
-        }
 
-      // Оновлюємо HUD
-      if (this.uiLogicBridge) {
-        const info = this.getRoadResourceInfo(object.id);
-        console.log(`[RoadRenderer.update] Road ${object.id} HUD check:`, {
-          hasInfo: !!info,
-          segmentsBuilt: info?.segmentsBuilt,
-          segmentsTotal: info?.segmentsTotal,
-          shouldShowHUD: info && info.segmentsBuilt < info.segmentsTotal
-        });
-        if (info && info.segmentsBuilt < info.segmentsTotal) {
-          // Anchor до першого сегмента
-          const first = (newSegments as RoadSegment[])[0];
-          const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
-          const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
-          const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
-          let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-          if (!hudAnchor) { hudAnchor = new THREE.Object3D(); hudAnchor.name = 'hudAnchor'; roadGroup.add(hudAnchor); }
-          hudAnchor.position.copy(head);
-          const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-          this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
-        } else {
-          console.log(`[RoadRenderer.update] Removing HUD for road ${object.id} - all segments completed`);
-          const hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-          if (hudAnchor) {
-            this.removeHUD(hudAnchor);
-          }
-        }
-      }
+    const roadGroup = this.meshes.get(object.id) as THREE.Group | undefined;
+    if (!roadGroup || !object.data?.roadSegments) {
+      return;
     }
+
+    const currentSegments = this.roadSegments.get(object.id);
+    const newSegments = object.data.roadSegments;
+    const segmentStates = object.data?.segmentStates || [];
+
+    if (!this.segmentsEqual(currentSegments, newSegments) || this.segmentStatesChanged(object.id, segmentStates)) {
+      this.remove(object.id);
+      this.render(object);
+      return;
+    }
+
+    const info = this.buildRoadResourceInfo(object);
+    const isFullyBuilt = !!object.data?.built;
+
+    if (!info || info.segmentsTotal === 0 || isFullyBuilt || info.segmentsBuilt >= info.segmentsTotal) {
+      this.removeRoadHUD(roadGroup, object.id);
+      return;
+    }
+
+    const first = (newSegments as RoadSegment[])[0];
+    if (!first) {
+      this.removeRoadHUD(roadGroup, object.id);
+      return;
+    }
+
+    const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
+    const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
+    const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
+
+    let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
+    if (!hudAnchor) {
+      hudAnchor = new THREE.Object3D();
+      hudAnchor.name = 'hudAnchor';
+      roadGroup.add(hudAnchor);
+    }
+    hudAnchor.position.copy(head);
+
+    const signature = this.createHudSignature(info);
+    const prevSignature = this.hudSignatures.get(object.id);
+    const hasHud = Boolean((hudAnchor as any).userData?.combinedHUD);
+
+    if (hasHud && prevSignature === signature) {
+      return;
+    }
+
+    this.hudSignatures.set(object.id, signature);
+    const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
+    this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
+  }
+
+  public override remove(id: string): void {
+    super.remove(id);
+    this.roadSegments.delete(id);
+    this.lastSegmentStates.delete(id);
+    this.hudSignatures.delete(id);
   }
 
   private segmentsEqual(segments1?: RoadSegment[], segments2?: RoadSegment[]): boolean {
@@ -316,8 +342,6 @@ export class RoadRenderer extends BaseRenderer {
              lastState?.constructionProgress !== newState?.constructionProgress;
     });
 
-    console.log('hasChanged: ', hasChanged, newStates.map((s,i) => `${i}:${s.id}:${s.buildingState}`).toString(), lastStates.map((s,i) => `${i}:${s.id}:${s.buildingState}`).toString());
-    
     // ВАЖЛИВО: оновлюємо кеш ТІЛЬКИ якщо є зміни
     if (hasChanged) {
       this.lastSegmentStates.set(roadId, newStates.map(s => ({ ...s })));
@@ -331,24 +355,29 @@ export class RoadRenderer extends BaseRenderer {
    */
   public removeRoad(roadId: string): void {
     this.remove(roadId);
-    this.roadSegments.delete(roadId);
-    this.lastSegmentStates.delete(roadId);
   }
 
   /**
    * Очищає всі дороги
    */
   public clearAllRoads(): void {
-    for (const roadId of this.roadSegments.keys()) {
+    for (const roadId of Array.from(this.roadSegments.keys())) {
       this.remove(roadId);
     }
     this.roadSegments.clear();
+    this.lastSegmentStates.clear();
+    this.hudSignatures.clear();
   }
 
   public dispose(): void {
     super.dispose();
     this.roadSegments.clear();
-    
+    this.lastSegmentStates.clear();
+    this.hudSignatures.clear();
+    this.cachedCanvasTexture?.dispose?.();
+    this.cachedCanvasTexture = null;
+    this.lastCanvasUpdate = 0;
+
     // Очищаємо матеріали
     if (this.roadMaterial) {
       this.roadMaterial.dispose();
@@ -360,6 +389,7 @@ export class RoadRenderer extends BaseRenderer {
 
   // ---------- Combined HUD (mirrors BuildingRenderer) ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; },
@@ -419,11 +449,10 @@ export class RoadRenderer extends BaseRenderer {
           final = Math.min(final, pxScale);
         }
         hud!.scale.set(final, final, final);
+        hud!.updateMatrixWorld(true);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -437,37 +466,12 @@ export class RoadRenderer extends BaseRenderer {
     }
   }
 
-  private removeHUD(anchor: THREE.Object3D): void {
-    const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    console.log(`[RoadRenderer.removeHUD] Anchor:`, anchor.name, `HUD found:`, !!hud);
-    if (hud) { 
-      // Видаляємо HUD зі сцени
-      this.scene.remove(hud);
-      
-      // Також робимо невидимим на всякий випадок
-      hud.visible = false;
-      
-      // Очищаємо всі дочірні об'єкти HUD
-      hud.clear();
-      
-      // Видаляємо матеріали та геометрії
-      hud.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
-          if (child.geometry) child.geometry.dispose();
-          if (child.material) {
-            if (Array.isArray(child.material)) {
-              child.material.forEach(mat => mat.dispose());
-            } else {
-              child.material.dispose();
-            }
-          }
-        }
-      });
-      
-      // Очищаємо посилання
-      (anchor as any).userData.combinedHUD = undefined;
-      console.log(`[RoadRenderer.removeHUD] HUD removed from scene and disposed`);
+  private removeRoadHUD(group: THREE.Object3D, roadId: string): void {
+    const hudAnchor = group.getObjectByName('hudAnchor') as THREE.Object3D | null;
+    if (hudAnchor) {
+      this.hudRegistry.detachFromAnchor(hudAnchor);
     }
+    this.hudSignatures.delete(roadId);
   }
 
   
@@ -479,11 +483,11 @@ export class RoadRenderer extends BaseRenderer {
     const showProgress = options?.showProgress !== false;
   
     const now = Date.now();
-    if (!options?.disableCache && now - (this as any).lastCanvasUpdate < 200) {
+    if (!options?.disableCache && now - this.lastCanvasUpdate < this.CANVAS_UPDATE_THROTTLE_MS) {
       const { texture } = this.getCachedCanvasTexture();
       return { texture, aspect: this.lastAspect, contentHeightWorld: this.lastContentHeightWorld };
     }
-    (this as any).lastCanvasUpdate = now;
+    this.lastCanvasUpdate = now;
   
     // БІЛЬШИЙ ТАРГЕТНИЙ РОЗМІР + без *1.5 (який зменшував ефективний розмір після clamp)
     const rendererDpr = (this as any).renderer?.getPixelRatio?.() ?? (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1;
@@ -674,25 +678,115 @@ export class RoadRenderer extends BaseRenderer {
     const predictedWidthPx = targetHeightPx * aspect; if (predictedWidthPx <= 0) return baseScale; const widthClamp = Math.max(1e-6, maxWidthPx / predictedWidthPx); return Math.min(baseScale, widthClamp * baseScale);
   }
 
-  // Convert road aggregates to ResourceInfo-like shape
-  private getRoadResourceInfo(roadId: string): { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; } | null {
-    if (!this.uiLogicBridge) return null;
-    const aggr = this.uiLogicBridge.getRoadAggregates(roadId);
-    if (!aggr) return null;
-    
-    // DEBUG: Логуємо що повертає getRoadAggregates
-    console.log(`[RoadRenderer.getRoadResourceInfo] Road ${roadId}:`, {
-      builtSegments: aggr.builtSegments,
-      totalSegments: aggr.totalSegments,
-      totalRequired: aggr.totalRequired,
-      totalDelivered: aggr.totalDelivered
-    });
-    const required = { ...aggr.totalRequired };
-    const collected = { ...aggr.totalDelivered };
+  // Build HUD resource info by combining segment states with optional manager aggregates
+  private buildRoadResourceInfo(object: TSceneObject): RoadHudInfo | null {
+    const segmentStates = (object.data?.segmentStates as any[]) ?? [];
+    const aggregates = this.uiLogicBridge?.getRoadAggregates(object.id) ?? null;
+
+    if (!segmentStates.length && !aggregates) {
+      return null;
+    }
+
+    const requiredTotals: Record<string, number> = {};
+    const deliveredTotals: Record<string, number> = {};
+    let segmentsBuiltFromStates = 0;
+    let segmentsTotal = segmentStates.length;
+
+    for (const state of segmentStates) {
+      if (!state) continue;
+
+      const builtFlag = state.buildingState === 'completed' || state.built === true;
+      const progressFlag = typeof state.constructionProgress === 'number' && state.constructionProgress >= 1;
+      if (builtFlag || progressFlag) {
+        segmentsBuiltFromStates += 1;
+      }
+
+      const required = state.requiredResources ?? {};
+      for (const [resource, amount] of Object.entries(required)) {
+        const reqVal = Math.max(0, Number(amount) || 0);
+        requiredTotals[resource] = (requiredTotals[resource] ?? 0) + reqVal;
+      }
+
+      const delivered = state.deliveredResources ?? {};
+      for (const [resource, amount] of Object.entries(delivered)) {
+        const deliveredVal = Math.max(0, Number(amount) || 0);
+        deliveredTotals[resource] = (deliveredTotals[resource] ?? 0) + deliveredVal;
+      }
+    }
+
+    if (aggregates) {
+      segmentsTotal = Math.max(segmentsTotal, aggregates.totalSegments ?? 0);
+      segmentsBuiltFromStates = Math.max(segmentsBuiltFromStates, aggregates.builtSegments ?? 0);
+
+      for (const [resource, amount] of Object.entries(aggregates.totalRequired ?? {})) {
+        const reqVal = Math.max(0, Number(amount) || 0);
+        requiredTotals[resource] = Math.max(requiredTotals[resource] ?? 0, reqVal);
+      }
+
+      for (const [resource, amount] of Object.entries(aggregates.totalDelivered ?? {})) {
+        const deliveredVal = Math.max(0, Number(amount) || 0);
+        deliveredTotals[resource] = Math.max(deliveredTotals[resource] ?? 0, deliveredVal);
+      }
+    }
+
+    if (segmentsTotal === 0) {
+      return null;
+    }
+
+    const required: Record<string, number> = {};
+    const collected: Record<string, number> = {};
     const missing: Record<string, number> = {};
-    let sumReq = 0, sumGot = 0;
-    for (const [k, v] of Object.entries(required)) { const got = collected[k] || 0; sumReq += v; sumGot += Math.min(v, got); if (got < v) missing[k] = v - got; }
-    const progress = sumReq > 0 ? sumGot / sumReq : 0;
-    return { required, collected, missing, progress, segmentsBuilt: aggr.builtSegments, segmentsTotal: aggr.totalSegments };
+    let totalRequired = 0;
+    let totalCollected = 0;
+
+    const resourceKeys = new Set<string>([
+      ...Object.keys(requiredTotals),
+      ...Object.keys(deliveredTotals)
+    ]);
+
+    for (const resource of resourceKeys) {
+      const requiredRaw = requiredTotals[resource] ?? 0;
+      const deliveredRaw = deliveredTotals[resource] ?? 0;
+      const reqVal = Math.max(0, Math.round(requiredRaw));
+      const deliveredVal = Math.max(0, Math.round(deliveredRaw));
+
+      if (reqVal === 0 && deliveredVal === 0) {
+        continue;
+      }
+
+      required[resource] = reqVal;
+      const clamped = Math.min(reqVal, deliveredVal);
+      collected[resource] = clamped;
+      totalRequired += reqVal;
+      totalCollected += clamped;
+
+      if (clamped < reqVal) {
+        missing[resource] = reqVal - clamped;
+      }
+    }
+
+    const progress = totalRequired > 0 ? Math.min(1, totalCollected / totalRequired) : 0;
+
+    return {
+      required,
+      collected,
+      missing,
+      progress,
+      segmentsBuilt: Math.min(segmentsBuiltFromStates, segmentsTotal),
+      segmentsTotal
+    };
+  }
+
+  private createHudSignature(info: RoadHudInfo): string {
+    const resources = Object.keys(info.required).sort();
+    const resourcePart = resources
+      .map((resource) => `${resource}:${info.required[resource]}:${info.collected[resource] ?? 0}`)
+      .join(',');
+
+    return [
+      `p:${info.progress.toFixed(4)}`,
+      `seg:${info.segmentsBuilt}/${info.segmentsTotal}`,
+      `res:${resourcePart}`
+    ].join('|');
   }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+
+type HudSet = Set<THREE.Object3D>;
+
+type HudUserData = {
+  combinedHUD?: THREE.Object3D;
+  __hudOwnerId?: string;
+} & THREE.Object3D['userData'];
+
+export class HudRegistry {
+  private readonly scene: THREE.Scene;
+  private readonly registry = new Map<string, HudSet>();
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+  }
+
+  public register(ownerId: string, anchor: THREE.Object3D, hud: THREE.Object3D): void {
+    const set = this.ensureSet(ownerId);
+    set.add(hud);
+
+    if (hud.parent !== this.scene) {
+      this.scene.add(hud);
+    }
+
+    const data = this.ensureUserData(anchor) as HudUserData;
+    data.__hudOwnerId = ownerId;
+    data.combinedHUD = hud;
+  }
+
+  public detachFromAnchor(anchor: THREE.Object3D): void {
+    const data = anchor.userData as HudUserData | undefined;
+    if (!data) return;
+
+    const hud = data.combinedHUD;
+    if (!hud) return;
+
+    const ownerId = data.__hudOwnerId;
+    this.detach(ownerId, hud);
+
+    delete data.combinedHUD;
+    if (ownerId) delete data.__hudOwnerId;
+  }
+
+  public detachAll(ownerId: string): void {
+    const set = this.registry.get(ownerId);
+    if (!set) return;
+
+    for (const hud of Array.from(set)) {
+      this.disposeHud(hud);
+      set.delete(hud);
+    }
+
+    this.registry.delete(ownerId);
+  }
+
+  public detachFromObjectGraph(root: THREE.Object3D): void {
+    root.traverse((node) => {
+      this.detachFromAnchor(node);
+    });
+  }
+
+  public dispose(): void {
+    for (const ownerId of Array.from(this.registry.keys())) {
+      this.detachAll(ownerId);
+    }
+    this.registry.clear();
+  }
+
+  private detach(ownerId: string | undefined, hud: THREE.Object3D): void {
+    if (ownerId) {
+      const set = this.registry.get(ownerId);
+      if (set && set.delete(hud) && set.size === 0) {
+        this.registry.delete(ownerId);
+      }
+    } else {
+      this.detachBySearch(hud);
+    }
+
+    this.disposeHud(hud);
+  }
+
+  private detachBySearch(hud: THREE.Object3D): void {
+    for (const [id, set] of this.registry.entries()) {
+      if (set.delete(hud)) {
+        if (set.size === 0) {
+          this.registry.delete(id);
+        }
+        break;
+      }
+    }
+  }
+
+  private disposeHud(hud: THREE.Object3D): void {
+    this.scene.remove(hud);
+    hud.removeFromParent();
+
+    hud.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) {
+        const mesh = child as THREE.Mesh;
+        mesh.geometry?.dispose();
+        this.disposeMaterial(mesh.material);
+      }
+    });
+
+    hud.clear();
+  }
+
+  private disposeMaterial(material: THREE.Material | THREE.Material[] | undefined): void {
+    if (!material) return;
+
+    if (Array.isArray(material)) {
+      material.forEach((mat) => this.disposeMaterial(mat));
+      return;
+    }
+
+    const mat = material as THREE.Material & { map?: THREE.Texture };
+    if (mat.map) {
+      mat.map.dispose?.();
+    }
+
+    mat.dispose?.();
+  }
+
+  private ensureSet(ownerId: string): HudSet {
+    let set = this.registry.get(ownerId);
+    if (!set) {
+      set = new Set();
+      this.registry.set(ownerId, set);
+    }
+    return set;
+  }
+
+  private ensureUserData(anchor: THREE.Object3D): THREE.Object3D['userData'] {
+    if (!anchor.userData) {
+      anchor.userData = {};
+    }
+    return anchor.userData;
+  }
+}


### PR DESCRIPTION
## Summary
- refresh billboard matrices for building and road HUDs so they keep up with rapid camera rotation
- rebuild the road HUD pipeline to merge segment state data with bridge aggregates, skip redundant redraws, and tear down overlays when a road completes
- clear stored HUD signatures and cached textures whenever roads are removed or the renderer is disposed to avoid stale canvases

## Testing
- npm run build *(fails: repository already contains pre-existing TypeScript errors outside of these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6bddd5883208904aa039ea71b0a