### PR TITLE
Scale HUD overlays and stabilize road HUD initialization

### DIFF
--- a/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BaseRenderer.ts
@@ -1,14 +1,17 @@
 import * as THREE from 'three'
 import { TSceneObject } from '@logic/systems/scene/scene.types'
+import { HudRegistry } from './hud/HudRegistry'
 
 export abstract class BaseRenderer {
     protected scene: THREE.Scene;
     protected renderer?: THREE.WebGLRenderer;
     protected meshes: Map<string, THREE.Object3D> = new Map();
+    protected hudRegistry: HudRegistry;
 
     constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
         this.scene = scene;
         this.renderer = renderer;
+        this.hudRegistry = new HudRegistry(scene);
     }
 
     abstract render(object: TSceneObject): THREE.Object3D;
@@ -34,6 +37,7 @@ export abstract class BaseRenderer {
     remove(id: string): void {
         const mesh = this.meshes.get(id);
         if (mesh) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
             this.meshes.delete(id);
         }
@@ -55,12 +59,12 @@ export abstract class BaseRenderer {
     // Очищення ресурсів (важливо для HMR!)
     // -------------------------
     public dispose(): void {
-        // Очищаємо всі меші з сцени
         for (const [_id, mesh] of this.meshes) {
+            this.hudRegistry.detachFromObjectGraph(mesh);
             this.scene.remove(mesh);
         }
-        
-        // Очищаємо Map
+
         this.meshes.clear();
+        this.hudRegistry.dispose();
     }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -4,49 +4,23 @@ import { UiLogicBridge } from '@ui/logic/UiLogicBridge';
 import { BaseRenderer } from './BaseRenderer';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
 import { BUILDINGS_DB } from '@logic/modules/buildings/buildings-db';
+import type { BuildingTypeId } from '@logic/modules/buildings/buildings.types';
 import { ResourceRequest } from '@logic/modules/resources/resource-types';
-import { RESOURCES_DB, ResourceId } from '@logic/modules/resources/resources-db';
-import { ResourceIcons } from './ResourceIcons';
+import { HudCanvasBuilder, BUILDING_HUD_STYLE } from './hud/HudCanvasBuilder';
+import type { HudCanvasRequest, HudResourceEntry } from './hud/HudCanvasBuilder';
+import { clampScaleByWidth, computeScreenSpaceScale } from './hud/hudMath';
 
 // ---------- TMP ----------
 const _qCam = new THREE.Quaternion();
 const _worldScale = new THREE.Vector3();
 const _worldPos = new THREE.Vector3();
 const _localOffset = new THREE.Vector3();
-const _camPos = new THREE.Vector3();
 const _viewDir = new THREE.Vector3();
 
 // ---------- Screen-space таргети ----------
-const HUD_TARGET_PX = {
-  resourceHeight: 72,
-  minScale: 0.1,
-  maxScale: 100.0,
-  maxWidth: 480,
-};
-
-const HUD_SAFE_FRACTION = 0.25;
-const HUD_CROP_X = HUD_SAFE_FRACTION;
-
 // Позиціонування у світі
 const HUD_WORLD_Y_OFFSET_FALLBACK = 0.6;
 const HUD_WORLD_Z_OFFSET = 0.035;
-
-// Висоти/ширини елементів у логічних px
-const PROGRESS_HEIGHT_PX = 7.5;
-const ROW_HEIGHT_PX      = 42;
-const ICON_SIZE_PX       = 36;
-
-const NAME_MIN_W_PX      = 180;
-const BAR_MIN_W_PX       = 75;
-const BAR_MAX_W_PX       = 240;
-const BAR_HEIGHT_PX      = 6;
-
-const SIDE_PAD_PX        = 24;
-const GAP_SMALL_PX       = 12;
-const GAP_MEDIUM_PX      = 18;
-const REQ_COL_W_PX       = 72;
-
-const INTERNAL_SCALE = 2;
 
 // --------- Типи ---------
 type ResourceInfo = {
@@ -61,18 +35,13 @@ export class BuildingRenderer extends BaseRenderer {
   private material: THREE.MeshBasicMaterial;
   private loader: GLTFLoader;
   private modelCache: Map<string, THREE.Group> = new Map();
-  private lastCanvasUpdate: number = 0;
-  private readonly CANVAS_UPDATE_THROTTLE_MS = 200;
-  private cachedCanvasTexture: THREE.CanvasTexture | null = null;
-
-  private lastAspect = 1;
-  private lastContentHeightWorld = 1;
+  private readonly hudStyle = BUILDING_HUD_STYLE;
+  private readonly hudBuilder: HudCanvasBuilder;
   
   private uiLogicBridge: UiLogicBridge | null = null; // Bridge to logic for storage info
 
   constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
     super(scene, renderer);
-    (this as any).renderer = renderer;
 
     this.geometry = new THREE.BoxGeometry(1, 1, 1);
     this.material = new THREE.MeshBasicMaterial({
@@ -86,6 +55,7 @@ export class BuildingRenderer extends BaseRenderer {
     });
 
     this.loader = new GLTFLoader();
+    this.hudBuilder = new HudCanvasBuilder(renderer, this.hudStyle);
   }
 
   /**
@@ -136,7 +106,7 @@ export class BuildingRenderer extends BaseRenderer {
 
   render(object: TSceneObject): THREE.Object3D {
     const data: any = object.data || {};
-    const buildingType = data?.typeId || data?.buildingType || 'storage';
+    const buildingType = (data?.typeId || data?.buildingType || 'storage') as BuildingTypeId;
     const config = BUILDINGS_DB.get(buildingType);
 
     // контейнер-якір
@@ -293,16 +263,19 @@ export class BuildingRenderer extends BaseRenderer {
     baseParentScale: number,
     options?: { showProgress?: boolean; disableCache?: boolean; title?: string }
   ): void {
+    const request = this.createHudRequest(constructionProgress, resourceInfo, {
+      showProgress: options?.showProgress,
+      title: options?.title,
+    });
+
+    const { texture, aspect, contentHeightWorld, cropX } = this.hudBuilder.build(request, {
+      disableCache: options?.disableCache,
+    });
+
+    const planeH = contentHeightWorld;
+    const planeW = contentHeightWorld * aspect * cropX;
+
     let hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-
-    const { texture, aspect, contentHeightWorld } =
-      this.buildCombinedCanvasTexture(constructionProgress, resourceInfo, options);
-
-    const baseW = contentHeightWorld * aspect;
-    const baseH = contentHeightWorld;
-    const cropX = HUD_CROP_X;
-    const planeW = baseW * cropX;
-    const planeH = baseH;
 
     if (!hud) {
       hud = new THREE.Group();
@@ -310,33 +283,23 @@ export class BuildingRenderer extends BaseRenderer {
       hud.renderOrder = 1100;
       hud.frustumCulled = false;
 
-      const bg = new THREE.Mesh(
-        new THREE.PlaneGeometry(planeW, planeH),
-        new THREE.MeshBasicMaterial({
-          map: texture,
-          transparent: true,
-          opacity: 1.0,
-          side: THREE.DoubleSide,
-          toneMapped: false,
-          fog: false,
-          depthTest: false,
-          depthWrite: false,
-        })
-      );
+      const material = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+        opacity: 1.0,
+        side: THREE.DoubleSide,
+        toneMapped: false,
+        fog: false,
+        depthTest: false,
+        depthWrite: false,
+      });
+
+      const bg = new THREE.Mesh(new THREE.PlaneGeometry(planeW, planeH), material);
       bg.name = 'hudPlane';
+      bg.frustumCulled = false;
+      this.applyHudTextureCrop(material, cropX);
 
-      if ((bg.material as THREE.MeshBasicMaterial).map) {
-        const map = (bg.material as THREE.MeshBasicMaterial).map!;
-        map.wrapS = THREE.ClampToEdgeWrapping;
-        map.wrapT = THREE.ClampToEdgeWrapping;
-        map.repeat.set(cropX, 1);
-        map.offset.set((1 - cropX) * 0.5, 0);
-        map.needsUpdate = true;
-      }
-
-      hud.add(bg);
-
-      const rendererRef = (this as any).renderer as THREE.WebGLRenderer | undefined;
+      const rendererRef = this.renderer;
       (bg as any).onBeforeRender = (_r: any, _s: any, camera: THREE.Camera) => {
         const extraY = (anchor as any).userData?.hudYOffset ?? 0;
 
@@ -348,36 +311,30 @@ export class BuildingRenderer extends BaseRenderer {
         hud!.quaternion.copy(_qCam);
 
         (camera as any).getWorldDirection?.(_viewDir) ?? _viewDir.set(0, 0, -1).applyQuaternion(_qCam);
-        const pos = _worldPos.clone().addScaledVector(_viewDir, -HUD_WORLD_Z_OFFSET);
-        hud!.position.copy(pos);
+        hud!.position.copy(_worldPos).addScaledVector(_viewDir, -HUD_WORLD_Z_OFFSET);
 
         anchor.getWorldScale(_worldScale);
-        const sx = _worldScale.x || 1, sy = _worldScale.y || 1, sz = _worldScale.z || 1;
         const base = 1 / Math.max(baseParentScale, 1e-6);
-        // const anti = base / Math.max(Math.max(sx, sy), sz); // Коментуємо антискейл
+        const planeAspect = planeW / Math.max(1e-6, planeH);
 
-        const screenS = this.computeScreenSpaceScale(
-          camera, hud!.position, planeH, Math.round(HUD_TARGET_PX.resourceHeight), rendererRef
+        const screenScale = computeScreenSpaceScale(
+          camera,
+          hud!.position,
+          planeH,
+          this.hudStyle.targetHeightPx,
+          rendererRef,
+          this.hudStyle.minScale,
+          this.hudStyle.maxScale
         );
 
-        // Використовуємо тільки screen-space scale без компенсації скейлу моделі
-        let final = base * screenS;
-        if (rendererRef) {
-          const pxScale = this.computeWidthClampScale(
-            camera,
-            hud!.position,
-            planeH,
-            Math.round(HUD_TARGET_PX.resourceHeight),
-            planeW / planeH,
-            HUD_TARGET_PX.maxWidth,
-            rendererRef
-          );
-          final = Math.min(final, pxScale);
-        }
+        let final = base * screenScale;
+        final = clampScaleByWidth(final, planeAspect, this.hudStyle.targetHeightPx, this.hudStyle.maxWidthPx);
+
         hud!.scale.set(final, final, final);
         hud!.updateMatrixWorld(true);
       };
 
+      hud.add(bg);
       this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
@@ -393,13 +350,7 @@ export class BuildingRenderer extends BaseRenderer {
         bg.geometry = new THREE.PlaneGeometry(planeW, planeH);
       }
 
-      if (mat.map) {
-        mat.map.wrapS = THREE.ClampToEdgeWrapping;
-        mat.map.wrapT = THREE.ClampToEdgeWrapping;
-        mat.map.repeat.set(cropX, 1);
-        mat.map.offset.set((1 - cropX) * 0.5, 0);
-        mat.needsUpdate = true;
-      }
+      this.applyHudTextureCrop(mat, cropX);
     }
   }
 
@@ -407,244 +358,45 @@ export class BuildingRenderer extends BaseRenderer {
     this.hudRegistry.detachFromAnchor(anchor);
   }
 
-  // ---------- Canvas builder ----------
-  private buildCombinedCanvasTexture(
-    constructionProgress: number,
+  private applyHudTextureCrop(material: THREE.MeshBasicMaterial, cropX: number): void {
+    const map = material.map;
+    if (!map) return;
+
+    map.wrapS = THREE.ClampToEdgeWrapping;
+    map.wrapT = THREE.ClampToEdgeWrapping;
+    map.repeat.set(cropX, 1);
+    map.offset.set((1 - cropX) * 0.5, 0);
+    map.needsUpdate = true;
+  }
+
+  private createHudRequest(
+    progress: number,
     resourceInfo: ResourceInfo,
-    options?: { showProgress?: boolean; disableCache?: boolean; title?: string }
-  ): { texture: THREE.CanvasTexture; aspect: number; contentHeightWorld: number } {
+    options?: { showProgress?: boolean; title?: string }
+  ): HudCanvasRequest {
+    const ids = new Set<string>([
+      ...Object.keys(resourceInfo.required || {}),
+      ...Object.keys(resourceInfo.collected || {}),
+    ]);
+
+    const resources: HudResourceEntry[] = Array.from(ids).map((id) => ({
+      id,
+      required: resourceInfo.required[id] ?? 0,
+      collected: resourceInfo.collected[id] ?? 0,
+    }));
+
     const showProgress = options?.showProgress !== false;
-    const now = Date.now();
-    if (!options?.disableCache && now - this.lastCanvasUpdate < this.CANVAS_UPDATE_THROTTLE_MS) {
-      const { texture } = this.getCachedCanvasTexture();
-      return { texture, aspect: this.lastAspect, contentHeightWorld: this.lastContentHeightWorld };
-    }
-    this.lastCanvasUpdate = now;
 
-    const rendererDpr =
-      this.renderer?.getPixelRatio?.() ??
-      (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1;
-    const dpr = rendererDpr * INTERNAL_SCALE;
-
-    const baseWidth = 1024;
-    const widthRaw = Math.round(baseWidth * dpr);
-
-    const rows = Math.max(1, Object.keys(resourceInfo.required).length);
-    const pad  = Math.round(18 * dpr);
-
-    const progressH = showProgress ? Math.round(PROGRESS_HEIGHT_PX * dpr) : 0;
-    const rowH      = Math.round(ROW_HEIGHT_PX * dpr);
-    const vGap      = Math.round(15 * dpr);
-
-    const titleH = options?.title ? Math.round(30 * dpr) : 0;
-    const heightRaw = pad + titleH + (titleH ? vGap : 0) + progressH + (showProgress ? vGap : 0) + rows * rowH + pad;
-
-    const toPOT = (v: number) => THREE.MathUtils.ceilPowerOfTwo(Math.max(2, v));
-    const width  = toPOT(widthRaw);
-    const height = toPOT(heightRaw);
-
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d')!;
-
-    ctx.fillStyle = 'rgba(0,0,0,0.92)';
-    ctx.fillRect(0, 0, width, height);
-
-    const safeW = Math.round(widthRaw * HUD_SAFE_FRACTION);
-    const safeX = Math.round((widthRaw - safeW) * 0.5);
-    const safeRight = safeX + safeW;
-
-    const px = (val: number) => Math.round(val * dpr);
-    const sidePad = px(SIDE_PAD_PX);
-    const gapS = px(GAP_SMALL_PX);
-    const gapM = px(GAP_MEDIUM_PX);
-    const reqColW = px(REQ_COL_W_PX);
-
-    const contentLeft  = safeX + sidePad;
-    const contentRight = safeRight - sidePad;
-
-    let cursorTop = pad;
-
-    if (options?.title) {
-      ctx.font = `${px(24)}px Inter, Arial, sans-serif`;
-      ctx.fillStyle = '#ffffff';
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'top';
-      const titleX = contentLeft;
-      ctx.fillText(options.title, titleX, cursorTop);
-      cursorTop += titleH + vGap;
-    }
-
-    if (showProgress) {
-      const progressX = contentLeft;
-      const progressW = Math.max(1, contentRight - contentLeft);
-      const progressY = cursorTop;
-
-      ctx.fillStyle = 'rgba(255,255,255,0.18)';
-      ctx.fillRect(progressX - px(3), progressY - px(3), progressW + px(6), progressH + px(6));
-      ctx.fillStyle = 'rgba(255,255,255,0.12)';
-      ctx.fillRect(progressX, progressY, progressW, progressH);
-      ctx.fillStyle = '#12d06b';
-      ctx.fillRect(
-        progressX,
-        progressY,
-        Math.max(px(9), Math.round(progressW * THREE.MathUtils.clamp(constructionProgress, 0, 1))),
-        progressH
-      );
-    }
-
-    const iconSize = px(ICON_SIZE_PX);
-    const iconX = contentLeft;
-
-    const reqX = contentRight;
-    const rightLimit = reqX - reqColW;
-
-    const nameX = iconX + iconSize + gapS;
-
-    const availableBetween = Math.max(0, rightLimit - nameX - gapM);
-    const NAME_MIN_W = px(NAME_MIN_W_PX);
-    const BAR_MIN_W  = px(BAR_MIN_W_PX);
-    const BAR_MAX_W  = px(BAR_MAX_W_PX);
-    const barH       = px(BAR_HEIGHT_PX);
-
-    const ellipsis = '…';
-    const truncateText = (text: string, maxW: number, font: string) => {
-      ctx.font = font;
-      if (maxW <= 0) return ellipsis;
-      if (ctx.measureText(text).width <= maxW) return text;
-      let lo = 0, hi = text.length;
-      while (lo < hi) {
-        const mid = ((lo + hi) / 2) | 0;
-        const s = text.slice(0, mid) + ellipsis;
-        if (ctx.measureText(s).width <= maxW) lo = mid + 1; else hi = mid;
-      }
-      return text.slice(0, Math.max(0, lo - 1)) + ellipsis;
-    };
-
-    const nameFont = `${px(27)}px Inter, Arial, sans-serif`;
-    const qtyFont  = `${px(24)}px Inter, Arial, sans-serif`;
-
-    let i = 0;
-    const startY = cursorTop + progressH + (showProgress ? vGap : 0);
-
-    for (const [resourceId, reqAmt] of Object.entries(resourceInfo.required)) {
-      const got = resourceInfo.collected[resourceId] || 0;
-      const miss = Math.max(0, reqAmt - got);
-      const done = miss === 0;
-
-      const rowCenterY = startY + i * rowH + Math.round(rowH * 0.5);
-
-      let nameMaxW = Math.round(availableBetween * 0.55);
-      let barW     = availableBetween - nameMaxW;
-
-      if (nameMaxW < NAME_MIN_W) { const d = NAME_MIN_W - nameMaxW; nameMaxW += d; barW -= d; }
-      if (barW < BAR_MIN_W)       { const d = BAR_MIN_W - barW;     barW += d;     nameMaxW -= d; }
-      nameMaxW = Math.max(px(120), nameMaxW);
-      barW     = Math.min(BAR_MAX_W, Math.max(BAR_MIN_W, barW));
-
-      const barX = nameX + nameMaxW + gapM;
-
-      const res = RESOURCES_DB[resourceId as ResourceId];
-      const hex = res?.color ?? '#cccccc';
-      const iconY = rowCenterY - Math.round(iconSize / 2);
-      this.drawResourceIcon(ctx, resourceId, iconX, iconY, iconSize, hex, done);
-
-      const name = res?.name ?? resourceId;
-      const nameY = rowCenterY + px(1.5);
-      ctx.fillStyle = done ? '#12d06b' : '#ffffff';
-      const clippedName = truncateText(name, nameMaxW, nameFont);
-      ctx.font = nameFont;
-      ctx.textBaseline = 'middle';
-      ctx.textAlign = 'left';
-      ctx.fillText(clippedName, nameX, nameY);
-
-      const p = reqAmt > 0 ? Math.max(0, Math.min(1, got / reqAmt)) : 1;
-      const bY = rowCenterY - Math.round(barH / 2);
-      ctx.fillStyle = 'rgba(255,255,255,0.20)';
-      ctx.fillRect(barX - px(3), bY - px(3), barW + px(6), barH + px(6));
-      ctx.fillStyle = 'rgba(255,255,255,0.12)';
-      ctx.fillRect(barX, bY, barW, barH);
-      ctx.fillStyle = done ? '#12d06b' : '#ff4444';
-      ctx.fillRect(barX, bY, Math.max(px(9), Math.round(barW * p)), barH);
-
-      ctx.font = qtyFont;
-      ctx.fillStyle = '#e6e6e6';
-      ctx.textBaseline = 'middle';
-      ctx.textAlign = 'right';
-      ctx.fillText(String(reqAmt), reqX, rowCenterY);
-
-      i++;
-    }
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.colorSpace = THREE.SRGBColorSpace;
-    texture.generateMipmaps = true;
-    texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.anisotropy = this.renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
-    texture.needsUpdate = true;
-
-    this.cachedCanvasTexture = texture;
-
-    const aspect = widthRaw / heightRaw;
-    const contentHeightWorld = 1.0;
-
-    this.lastAspect = aspect;
-    this.lastContentHeightWorld = contentHeightWorld;
-
-    return { texture, aspect, contentHeightWorld };
-  }
-
-  // ---------- Helpers ----------
-  private getCachedCanvasTexture(): { texture: THREE.CanvasTexture; aspect: number; contentHeightWorld: number } {
-    if (!this.cachedCanvasTexture) {
-      const canvas = document.createElement('canvas');
-      canvas.width = 2;
-      canvas.height = 2;
-      const tex = new THREE.CanvasTexture(canvas);
-      tex.colorSpace = THREE.SRGBColorSpace;
-      tex.generateMipmaps = false;
-      tex.minFilter = THREE.LinearFilter;
-      tex.magFilter = THREE.LinearFilter;
-      this.cachedCanvasTexture = tex;
-    }
     return {
-      texture: this.cachedCanvasTexture,
-      aspect: this.lastAspect,
-      contentHeightWorld: this.lastContentHeightWorld
+      title: options?.title,
+      progress: showProgress ? THREE.MathUtils.clamp(progress, 0, 1) : 0,
+      showProgress,
+      resources,
     };
-  }
-
-  private drawResourceIcon(
-    ctx: CanvasRenderingContext2D,
-    resourceId: string,
-    x: number,
-    y: number,
-    size: number,
-    color: string,
-    isComplete: boolean = false
-  ): void {
-    const iconColor = isComplete ? '#12d06b' : color;
-    const svgString = ResourceIcons.getIconForResource(resourceId, iconColor);
-
-    const img = new Image();
-    const svgBlob = new Blob([svgString], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(svgBlob);
-
-    img.onload = () => {
-      ctx.drawImage(img, Math.round(x), Math.round(y), Math.round(size), Math.round(size));
-      URL.revokeObjectURL(url);
-      if (this.cachedCanvasTexture) {
-        this.cachedCanvasTexture.needsUpdate = true;
-      }
-    };
-
-    img.src = url;
   }
 
   private getBuildingResourceInfo(
-    buildingType: string,
+    buildingType: BuildingTypeId,
     resourcesCollected: Record<string, number> = {}
   ): ResourceInfo {
     const buildingConfig = BUILDINGS_DB.get(buildingType);
@@ -685,67 +437,6 @@ export class BuildingRenderer extends BaseRenderer {
     return Math.max(1e-6, Math.max(anchor.scale.x, anchor.scale.y, anchor.scale.z));
   }
 
-  private computeScreenSpaceScale(
-    camera: THREE.Camera,
-    worldPos: THREE.Vector3,
-    planeWorldHeight: number,
-    targetPx: number,
-    renderer?: THREE.WebGLRenderer
-  ): number {
-    const size = renderer?.getSize(new THREE.Vector2());
-    const dpr =
-      renderer?.getPixelRatio?.() ??
-      (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1;
-    const viewportH =
-      (size?.y ?? (typeof window !== 'undefined' ? window.innerHeight : 800)) * dpr;
-
-    if ((camera as any).isOrthographicCamera) {
-      const cam = camera as THREE.OrthographicCamera;
-      const orthoHeight = Math.max(1e-6, cam.top - cam.bottom);
-      const pxPerWorld = viewportH / orthoHeight;
-      const currentPx = planeWorldHeight * pxPerWorld;
-      const s = Math.round(targetPx) / Math.max(1e-6, currentPx);
-      return THREE.MathUtils.clamp(s, HUD_TARGET_PX.minScale, HUD_TARGET_PX.maxScale);
-    }
-
-    if ((camera as any).isPerspectiveCamera) {
-      (camera as THREE.Object3D).getWorldPosition(_camPos);
-      const d = _camPos.distanceTo(worldPos);
-      const cam = camera as THREE.PerspectiveCamera;
-      const tan = Math.tan(THREE.MathUtils.degToRad(cam.fov) * 0.5);
-      const denom = Math.max(1e-6, 2 * d * tan);
-      const heightToPixels = viewportH / denom;
-      const s = Math.round(targetPx) / Math.max(1e-6, planeWorldHeight * heightToPixels);
-      return THREE.MathUtils.clamp(s, HUD_TARGET_PX.minScale, HUD_TARGET_PX.maxScale);
-    }
-
-    return 1;
-  }
-
-  private computeWidthClampScale(
-    camera: THREE.Camera,
-    worldPos: THREE.Vector3,
-    planeWorldHeight: number,
-    targetHeightPx: number,
-    aspect: number,
-    maxWidthPx: number,
-    renderer: THREE.WebGLRenderer
-  ): number {
-    // Compute current pixels per world unit using height, then derive width in px and clamp
-    const baseScale = this.computeScreenSpaceScale(
-      camera,
-      worldPos,
-      planeWorldHeight,
-      targetHeightPx,
-      renderer
-    );
-    // Predicted width in pixels if we used baseScale
-    const predictedWidthPx = targetHeightPx * aspect;
-    if (predictedWidthPx <= 0) return baseScale;
-    const widthClamp = Math.max(1e-6, maxWidthPx / predictedWidthPx);
-    return Math.min(baseScale, widthClamp * baseScale);
-  }
-
   public update(object: TSceneObject): void {
     super.update(object);
     const anchor = this.meshes.get(object.id);
@@ -758,25 +449,25 @@ export class BuildingRenderer extends BaseRenderer {
     const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
 
     if (isUnderConstruction) {
-      const buildingType = data?.typeId || data?.buildingType || 'storage';
+      const buildingType = (data?.typeId || data?.buildingType || 'storage') as BuildingTypeId;
       const info = this.getBuildingResourceInfo(buildingType, data?.resourcesCollected || {});
       const baseParentScale = this.getBaseParentScale(anchor);
 
       const storedBaseY = (anchor as any).userData?.constructionBarY ?? HUD_WORLD_Y_OFFSET_FALLBACK;
       const extraY = (anchor as any).userData?.hudYOffset ?? 0;
       const barY = storedBaseY + extraY;
-      
+
       if (hud) {
-        const { texture, aspect, contentHeightWorld } = this.buildCombinedCanvasTexture(p, info, { disableCache: true });
+        const request = this.createHudRequest(p, info);
+        const { texture, aspect, contentHeightWorld, cropX } = this.hudBuilder.build(request, { disableCache: true });
         const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
         const mat = bg.material as THREE.MeshBasicMaterial;
         mat.map?.dispose();
         mat.map = texture;
         mat.needsUpdate = true;
 
-        const baseW = contentHeightWorld * aspect;
-        const planeW = baseW * HUD_CROP_X;
         const planeH = contentHeightWorld;
+        const planeW = contentHeightWorld * aspect * cropX;
 
         const geo = bg.geometry as THREE.PlaneGeometry;
         const params = geo.parameters;
@@ -785,14 +476,7 @@ export class BuildingRenderer extends BaseRenderer {
           bg.geometry = new THREE.PlaneGeometry(planeW, planeH);
         }
 
-        // ВАЖЛИВО: повторно застосовуємо обрізання карти після заміни texture
-        if (mat.map) {
-          mat.map.wrapS = THREE.ClampToEdgeWrapping;
-          mat.map.wrapT = THREE.ClampToEdgeWrapping;
-          mat.map.repeat.set(HUD_CROP_X, 1);
-          mat.map.offset.set((1 - HUD_CROP_X) * 0.5, 0);
-          mat.needsUpdate = true;
-        }
+        this.applyHudTextureCrop(mat, cropX);
 
         (anchor as any).userData.constructionBarY = storedBaseY;
         (anchor as any).userData.hudYOffset = extraY;
@@ -801,7 +485,7 @@ export class BuildingRenderer extends BaseRenderer {
       }
     } else {
       // Built building: render storage HUD if internal storage present
-      const buildingType = data?.typeId || data?.buildingType || 'storage';
+      const buildingType = (data?.typeId || data?.buildingType || 'storage') as BuildingTypeId;
       const config = BUILDINGS_DB.get(buildingType);
       const hasInternal = this.buildingHasInternalStorage(object.id, config);
       if (hasInternal && this.uiLogicBridge) {
@@ -815,17 +499,17 @@ export class BuildingRenderer extends BaseRenderer {
 
           const title = config?.name ? `${config.name}` : (object.id || 'building');
           if (hud) {
-            const { texture, aspect, contentHeightWorld } =
-              this.buildCombinedCanvasTexture(0, resInfo, { showProgress: false, disableCache: true, title });
+            const request = this.createHudRequest(0, resInfo, { showProgress: false, title });
+            const { texture, aspect, contentHeightWorld, cropX } =
+              this.hudBuilder.build(request, { disableCache: true });
             const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
             const mat = bg.material as THREE.MeshBasicMaterial;
             mat.map?.dispose();
             mat.map = texture;
             mat.needsUpdate = true;
 
-            const baseW = contentHeightWorld * aspect;
-            const planeW = baseW * HUD_CROP_X;
             const planeH = contentHeightWorld;
+            const planeW = contentHeightWorld * aspect * cropX;
 
             const geo = bg.geometry as THREE.PlaneGeometry;
             const params = geo.parameters;
@@ -834,14 +518,7 @@ export class BuildingRenderer extends BaseRenderer {
               bg.geometry = new THREE.PlaneGeometry(planeW, planeH);
             }
 
-            // ВАЖЛИВО: це було відсутнє — саме воно й ламало скейл на частині будівель
-            if (mat.map) {
-              mat.map.wrapS = THREE.ClampToEdgeWrapping;
-              mat.map.wrapT = THREE.ClampToEdgeWrapping;
-              mat.map.repeat.set(HUD_CROP_X, 1);
-              mat.map.offset.set((1 - HUD_CROP_X) * 0.5, 0);
-              mat.needsUpdate = true;
-            }
+            this.applyHudTextureCrop(mat, cropX);
 
             (anchor as any).userData.constructionBarY = storedBaseY;
             (anchor as any).userData.hudYOffset = extraY;
@@ -868,6 +545,7 @@ export class BuildingRenderer extends BaseRenderer {
     this.geometry.dispose();
     this.material.dispose();
     this.modelCache.clear();
+    this.hudBuilder.dispose();
 
     super.dispose();
   }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -18,10 +18,10 @@ const _viewDir = new THREE.Vector3();
 
 // ---------- Screen-space таргети ----------
 const HUD_TARGET_PX = {
-  resourceHeight: 48,
+  resourceHeight: 72,
   minScale: 0.1,
   maxScale: 100.0,
-  maxWidth: 320,
+  maxWidth: 480,
 };
 
 const HUD_SAFE_FRACTION = 0.25;
@@ -32,19 +32,19 @@ const HUD_WORLD_Y_OFFSET_FALLBACK = 0.6;
 const HUD_WORLD_Z_OFFSET = 0.035;
 
 // Висоти/ширини елементів у логічних px
-const PROGRESS_HEIGHT_PX = 5;
-const ROW_HEIGHT_PX      = 28;
-const ICON_SIZE_PX       = 24;
+const PROGRESS_HEIGHT_PX = 7.5;
+const ROW_HEIGHT_PX      = 42;
+const ICON_SIZE_PX       = 36;
 
-const NAME_MIN_W_PX      = 120;
-const BAR_MIN_W_PX       = 50;
-const BAR_MAX_W_PX       = 160;
-const BAR_HEIGHT_PX      = 4;
+const NAME_MIN_W_PX      = 180;
+const BAR_MIN_W_PX       = 75;
+const BAR_MAX_W_PX       = 240;
+const BAR_HEIGHT_PX      = 6;
 
-const SIDE_PAD_PX        = 16;
-const GAP_SMALL_PX       = 8;
-const GAP_MEDIUM_PX      = 12;
-const REQ_COL_W_PX       = 48;
+const SIDE_PAD_PX        = 24;
+const GAP_SMALL_PX       = 12;
+const GAP_MEDIUM_PX      = 18;
+const REQ_COL_W_PX       = 72;
 
 const INTERNAL_SCALE = 2;
 
@@ -170,7 +170,7 @@ export class BuildingRenderer extends BaseRenderer {
       const baseParentScale = this.getBaseParentScale(container);
       const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
       const title = config?.name ? `${config.name}` : (object.id || 'building');
-      this.attachOrUpdateCombinedHUD(container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
+      this.attachOrUpdateCombinedHUD(object.id, container, constructionProgress, resourceInfo, baseY, baseParentScale, { title });
       (container as any).userData.constructionBarY = HUD_WORLD_Y_OFFSET_FALLBACK;
     } else {
       // Storage HUD via combined HUD without progress bar
@@ -182,7 +182,7 @@ export class BuildingRenderer extends BaseRenderer {
           const baseY = HUD_WORLD_Y_OFFSET_FALLBACK + userHudOffset;
           const resInfo = this.storageToResourceInfo(storageInfo);
           const title = config?.name ? `${config.name}` : (object.id || 'building');
-          this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
+          this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY, baseParentScale, { showProgress: false, disableCache: true, title });
         }
       } else {
         this.removeHUD(container);
@@ -242,6 +242,7 @@ export class BuildingRenderer extends BaseRenderer {
         const baseParentScale = this.getBaseParentScale(container);
         const resourceInfo = this.getBuildingResourceInfo(buildingType, data?.resourcesCollected || {});
         this.attachOrUpdateCombinedHUD(
+          object.id,
           container,
           constructionProgress,
           resourceInfo,
@@ -260,7 +261,7 @@ export class BuildingRenderer extends BaseRenderer {
             const baseParentScale = this.getBaseParentScale(container);
             const resInfo = this.storageToResourceInfo(storageInfo);
             const title = config?.name ? `${config.name}` : (object.id || 'building');
-            this.attachOrUpdateCombinedHUD(container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, container, 0, resInfo, baseY + userHudOffset, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(container);
@@ -284,6 +285,7 @@ export class BuildingRenderer extends BaseRenderer {
 
   // ---------- Combined HUD ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: ResourceInfo,
@@ -373,11 +375,10 @@ export class BuildingRenderer extends BaseRenderer {
           final = Math.min(final, pxScale);
         }
         hud!.scale.set(final, final, final);
+        hud!.updateMatrixWorld(true);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -403,11 +404,7 @@ export class BuildingRenderer extends BaseRenderer {
   }
 
   private removeHUD(anchor: THREE.Object3D) {
-    const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    if (hud) {
-      this.scene.remove(hud);
-      (anchor as any).userData.combinedHUD = undefined;
-    }
+    this.hudRegistry.detachFromAnchor(anchor);
   }
 
   // ---------- Canvas builder ----------
@@ -433,13 +430,13 @@ export class BuildingRenderer extends BaseRenderer {
     const widthRaw = Math.round(baseWidth * dpr);
 
     const rows = Math.max(1, Object.keys(resourceInfo.required).length);
-    const pad  = Math.round(12 * dpr);
+    const pad  = Math.round(18 * dpr);
 
     const progressH = showProgress ? Math.round(PROGRESS_HEIGHT_PX * dpr) : 0;
     const rowH      = Math.round(ROW_HEIGHT_PX * dpr);
-    const vGap      = Math.round(10 * dpr);
+    const vGap      = Math.round(15 * dpr);
 
-    const titleH = options?.title ? Math.round(20 * dpr) : 0;
+    const titleH = options?.title ? Math.round(30 * dpr) : 0;
     const heightRaw = pad + titleH + (titleH ? vGap : 0) + progressH + (showProgress ? vGap : 0) + rows * rowH + pad;
 
     const toPOT = (v: number) => THREE.MathUtils.ceilPowerOfTwo(Math.max(2, v));
@@ -470,7 +467,7 @@ export class BuildingRenderer extends BaseRenderer {
     let cursorTop = pad;
 
     if (options?.title) {
-      ctx.font = `${px(16)}px Inter, Arial, sans-serif`;
+      ctx.font = `${px(24)}px Inter, Arial, sans-serif`;
       ctx.fillStyle = '#ffffff';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
@@ -485,14 +482,14 @@ export class BuildingRenderer extends BaseRenderer {
       const progressY = cursorTop;
 
       ctx.fillStyle = 'rgba(255,255,255,0.18)';
-      ctx.fillRect(progressX - px(2), progressY - px(2), progressW + px(4), progressH + px(4));
+      ctx.fillRect(progressX - px(3), progressY - px(3), progressW + px(6), progressH + px(6));
       ctx.fillStyle = 'rgba(255,255,255,0.12)';
       ctx.fillRect(progressX, progressY, progressW, progressH);
       ctx.fillStyle = '#12d06b';
       ctx.fillRect(
         progressX,
         progressY,
-        Math.max(px(6), Math.round(progressW * THREE.MathUtils.clamp(constructionProgress, 0, 1))),
+        Math.max(px(9), Math.round(progressW * THREE.MathUtils.clamp(constructionProgress, 0, 1))),
         progressH
       );
     }
@@ -525,8 +522,8 @@ export class BuildingRenderer extends BaseRenderer {
       return text.slice(0, Math.max(0, lo - 1)) + ellipsis;
     };
 
-    const nameFont = `${px(18)}px Inter, Arial, sans-serif`;
-    const qtyFont  = `${px(16)}px Inter, Arial, sans-serif`;
+    const nameFont = `${px(27)}px Inter, Arial, sans-serif`;
+    const qtyFont  = `${px(24)}px Inter, Arial, sans-serif`;
 
     let i = 0;
     const startY = cursorTop + progressH + (showProgress ? vGap : 0);
@@ -543,7 +540,7 @@ export class BuildingRenderer extends BaseRenderer {
 
       if (nameMaxW < NAME_MIN_W) { const d = NAME_MIN_W - nameMaxW; nameMaxW += d; barW -= d; }
       if (barW < BAR_MIN_W)       { const d = BAR_MIN_W - barW;     barW += d;     nameMaxW -= d; }
-      nameMaxW = Math.max(px(80), nameMaxW);
+      nameMaxW = Math.max(px(120), nameMaxW);
       barW     = Math.min(BAR_MAX_W, Math.max(BAR_MIN_W, barW));
 
       const barX = nameX + nameMaxW + gapM;
@@ -554,7 +551,7 @@ export class BuildingRenderer extends BaseRenderer {
       this.drawResourceIcon(ctx, resourceId, iconX, iconY, iconSize, hex, done);
 
       const name = res?.name ?? resourceId;
-      const nameY = rowCenterY + px(1);
+      const nameY = rowCenterY + px(1.5);
       ctx.fillStyle = done ? '#12d06b' : '#ffffff';
       const clippedName = truncateText(name, nameMaxW, nameFont);
       ctx.font = nameFont;
@@ -565,11 +562,11 @@ export class BuildingRenderer extends BaseRenderer {
       const p = reqAmt > 0 ? Math.max(0, Math.min(1, got / reqAmt)) : 1;
       const bY = rowCenterY - Math.round(barH / 2);
       ctx.fillStyle = 'rgba(255,255,255,0.20)';
-      ctx.fillRect(barX - px(2), bY - px(2), barW + px(4), barH + px(4));
+      ctx.fillRect(barX - px(3), bY - px(3), barW + px(6), barH + px(6));
       ctx.fillStyle = 'rgba(255,255,255,0.12)';
       ctx.fillRect(barX, bY, barW, barH);
       ctx.fillStyle = done ? '#12d06b' : '#ff4444';
-      ctx.fillRect(barX, bY, Math.max(px(6), Math.round(barW * p)), barH);
+      ctx.fillRect(barX, bY, Math.max(px(9), Math.round(barW * p)), barH);
 
       ctx.font = qtyFont;
       ctx.fillStyle = '#e6e6e6';
@@ -800,7 +797,7 @@ export class BuildingRenderer extends BaseRenderer {
         (anchor as any).userData.constructionBarY = storedBaseY;
         (anchor as any).userData.hudYOffset = extraY;
       } else {
-        this.attachOrUpdateCombinedHUD(anchor, p, info, barY, baseParentScale);
+        this.attachOrUpdateCombinedHUD(object.id, anchor, p, info, barY, baseParentScale);
       }
     } else {
       // Built building: render storage HUD if internal storage present
@@ -849,7 +846,7 @@ export class BuildingRenderer extends BaseRenderer {
             (anchor as any).userData.constructionBarY = storedBaseY;
             (anchor as any).userData.hudYOffset = extraY;
           } else {
-            this.attachOrUpdateCombinedHUD(anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
+            this.attachOrUpdateCombinedHUD(object.id, anchor, 0, resInfo, barY, baseParentScale, { showProgress: false, disableCache: true, title });
           }
         } else {
           this.removeHUD(anchor);
@@ -870,16 +867,9 @@ export class BuildingRenderer extends BaseRenderer {
   public dispose(): void {
     this.geometry.dispose();
     this.material.dispose();
-
-    this.meshes.forEach((mesh) => {
-      const hud = (mesh as any).userData?.combinedHUD as THREE.Group | undefined;
-      if (hud) this.scene.remove(hud);
-    });
-
-    this.meshes.forEach((mesh) => this.scene.remove(mesh));
-    this.meshes.clear();
-
     this.modelCache.clear();
+
+    super.dispose();
   }
 
   // ========== Storage HUD Methods ==========

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -36,6 +36,11 @@ export class RendererManager {
         if (buildingRenderer && buildingRenderer.setUiLogicBridge) {
             buildingRenderer.setUiLogicBridge(bridge);
         }
+
+        const roadRenderer = this.renderers.get('road') as any;
+        if (roadRenderer && roadRenderer.setUiLogicBridge) {
+            roadRenderer.setUiLogicBridge(bridge as any);
+        }
     }
 
     private initializeRenderers(): void {
@@ -48,7 +53,7 @@ export class RendererManager {
         })); // Каменюки типу rock з звичайним рендерингом
         this.registerRenderer('biomass', new BiomassRenderer(this.scene)); // Біомаса
         this.registerRenderer('rover', new RoverRenderer(this.scene)); // Rover об'єкти
-        const buildingRenderer = new BuildingRenderer(this.scene);
+        const buildingRenderer = new BuildingRenderer(this.scene, this.renderer);
         if (this.bridge && (buildingRenderer as any).setUiLogicBridge) {
             (buildingRenderer as any).setUiLogicBridge(this.bridge);
         }
@@ -56,7 +61,7 @@ export class RendererManager {
         this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Хмари
         this.registerRenderer('smoke', new SmokeRenderer(this.scene, this.renderer)); // Дим (GPU)
         this.registerRenderer('fire', new FireRenderer(this.scene, this.renderer)); // Вогонь (GPU)
-        const roadRenderer = new RoadRenderer(this.scene);
+        const roadRenderer = new RoadRenderer(this.scene, this.renderer);
         if (this.bridge && (roadRenderer as any).setUiLogicBridge) {
             (roadRenderer as any).setUiLogicBridge(this.bridge as any);
         }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
@@ -11,6 +11,15 @@ interface RoadSegment {
   width: number;
 }
 
+interface RoadHudInfo {
+  required: Record<string, number>;
+  collected: Record<string, number>;
+  missing: Record<string, number>;
+  progress: number;
+  segmentsBuilt: number;
+  segmentsTotal: number;
+}
+
 export class RoadRenderer extends BaseRenderer {
   private roadMaterial: THREE.Material;
   private plannedRoadMaterial: THREE.Material;
@@ -21,29 +30,32 @@ export class RoadRenderer extends BaseRenderer {
   private cachedCanvasTexture: THREE.CanvasTexture | null = null;
   private lastAspect = 1;
   private lastContentHeightWorld = 1;
+  private readonly CANVAS_UPDATE_THROTTLE_MS = 200;
+  private lastCanvasUpdate = 0;
+  private hudSignatures: Map<string, string> = new Map();
 
   // For roads use full canvas width to avoid left cropping
   private readonly HUD_SAFE_FRACTION = 1.0;
   private readonly HUD_CROP_X = 1.0;
   private readonly HUD_WORLD_Z_OFFSET = 0.035;
 
-  private readonly PROGRESS_HEIGHT_PX = 5;
-  private readonly ROW_HEIGHT_PX = 28;
-  private readonly ICON_SIZE_PX = 24;
-  private readonly BAR_MIN_W_PX = 50;
-  private readonly BAR_HEIGHT_PX = 4;
-  private readonly SIDE_PAD_PX = 16;
-  private readonly GAP_SMALL_PX = 8;
-  private readonly GAP_MEDIUM_PX = 12;
+  private readonly PROGRESS_HEIGHT_PX = 7.5;
+  private readonly ROW_HEIGHT_PX = 42;
+  private readonly ICON_SIZE_PX = 36;
+  private readonly BAR_MIN_W_PX = 75;
+  private readonly BAR_HEIGHT_PX = 6;
+  private readonly SIDE_PAD_PX = 24;
+  private readonly GAP_SMALL_PX = 12;
+  private readonly GAP_MEDIUM_PX = 18;
 
-  private readonly HUD_TARGET_PX = { resourceHeight: 84, minScale: 0.1, maxScale: 100.0, maxWidth: 280 } as const;
-    private readonly NAME_MIN_W_PX = 110;
-    private readonly BAR_MAX_W_PX = 120;
-    private readonly REQ_COL_W_PX = 42;
-    private readonly INTERNAL_SCALE = 2;
+  private readonly HUD_TARGET_PX = { resourceHeight: 126, minScale: 0.1, maxScale: 100.0, maxWidth: 420 } as const;
+  private readonly NAME_MIN_W_PX = 165;
+  private readonly BAR_MAX_W_PX = 180;
+  private readonly REQ_COL_W_PX = 63;
+  private readonly INTERNAL_SCALE = 2;
 
-  constructor(scene: THREE.Scene) {
-    super(scene);
+  constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
+    super(scene, renderer);
     this.roadMaterial = this.createRoadMaterial();
     this.plannedRoadMaterial = this.createPlannedRoadMaterial();
   }
@@ -109,7 +121,6 @@ export class RoadRenderer extends BaseRenderer {
       const parentState = segmentStates[parentIdx];
       // Якщо вся дорога збудована (object.data.built) - всі сегменти вважаються збудованими
       const isSegmentPlanned = (isPlanned || !object.data?.built) && parentState?.buildingState !== 'completed';
-      console.log(`Road: ${object.id}`, isPlanned, object.data?.built, parentState, isSegmentPlanned);
       const segmentMesh = this.createSegmentMesh(segment, `${object.id}_segment_${index}`, isSegmentPlanned);
       roadGroup.add(segmentMesh);
     });
@@ -119,27 +130,39 @@ export class RoadRenderer extends BaseRenderer {
 
     this.addMesh(object.id, roadGroup);
 
-    // HUD над центром ПЕРШОГО сегмента
-    if (this.uiLogicBridge) {
-      const info = this.getRoadResourceInfo(object.id);
-      if (info && info.segmentsBuilt < info.segmentsTotal) {
-        // Обчислюємо anchor з першого сегмента
-        const first = segments[0];
-        const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
-        const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
-        const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
-        let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-        if (!hudAnchor) {
-          hudAnchor = new THREE.Object3D();
-          hudAnchor.name = 'hudAnchor';
-          roadGroup.add(hudAnchor);
-        }
-        hudAnchor.position.copy(head);
-        const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-        this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
-      } else {
-        console.log(`[RoadRenderer.render] Not showing HUD for road ${object.id} - all segments completed`);
+    const info = this.buildRoadResourceInfo(object, segments.length);
+    const isFullyBuilt = !!object.data?.built;
+
+    if (!info) {
+      this.hudRegistry.detachAll(object.id);
+      this.hudSignatures.delete(object.id);
+      return roadGroup;
+    }
+
+    const shouldShowHud =
+      !isFullyBuilt &&
+      info.segmentsTotal > 0 &&
+      (info.progress < 1 || info.segmentsBuilt < info.segmentsTotal);
+
+    if (shouldShowHud) {
+      const first = segments[0];
+      const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
+      const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
+      const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
+      let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
+      if (!hudAnchor) {
+        hudAnchor = new THREE.Object3D();
+        hudAnchor.name = 'hudAnchor';
+        roadGroup.add(hudAnchor);
       }
+      hudAnchor.position.copy(head);
+      const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
+      const signature = this.createHudSignature(info);
+      this.hudSignatures.set(object.id, signature);
+      this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
+    } else {
+      this.hudRegistry.detachAll(object.id);
+      this.hudSignatures.delete(object.id);
     }
     return roadGroup;
   }
@@ -200,8 +223,6 @@ export class RoadRenderer extends BaseRenderer {
     const mesh = new THREE.Mesh(geometry, material);
     mesh.name = name;
 
-    console.log('createSegmentMesh called: ', isPlanned);
-    
     return mesh;
   }
 
@@ -233,51 +254,78 @@ export class RoadRenderer extends BaseRenderer {
 
 
   update(object: TSceneObject): void {
-    // Базове оновлення позиції від BaseRenderer
     super.update(object);
-    
-    // Додаткова логіка оновлення дороги якщо потрібно
-    const roadGroup = this.meshes.get(object.id);
-    if (roadGroup && object.data?.roadSegments) {
-      // Якщо сегменти змінилися - перебудовуємо дорогу
-      const currentSegments = this.roadSegments.get(object.id);
-      const newSegments = object.data.roadSegments;
-      const segmentStates = object.data?.segmentStates || [];
-        if (!this.segmentsEqual(currentSegments, newSegments) || this.segmentStatesChanged(object.id, segmentStates)) {
-          this.remove(object.id);
-          this.render(object);
-          console.log('Re-render: ', object, !!this.uiLogicBridge);
-        }
 
-      // Оновлюємо HUD
-      if (this.uiLogicBridge) {
-        const info = this.getRoadResourceInfo(object.id);
-        console.log(`[RoadRenderer.update] Road ${object.id} HUD check:`, {
-          hasInfo: !!info,
-          segmentsBuilt: info?.segmentsBuilt,
-          segmentsTotal: info?.segmentsTotal,
-          shouldShowHUD: info && info.segmentsBuilt < info.segmentsTotal
-        });
-        if (info && info.segmentsBuilt < info.segmentsTotal) {
-          // Anchor до першого сегмента
-          const first = (newSegments as RoadSegment[])[0];
-          const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
-          const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
-          const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
-          let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-          if (!hudAnchor) { hudAnchor = new THREE.Object3D(); hudAnchor.name = 'hudAnchor'; roadGroup.add(hudAnchor); }
-          hudAnchor.position.copy(head);
-          const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
-          this.attachOrUpdateCombinedHUD(hudAnchor, info.progress, info, 0.6, 1, { title });
-        } else {
-          console.log(`[RoadRenderer.update] Removing HUD for road ${object.id} - all segments completed`);
-          const hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
-          if (hudAnchor) {
-            this.removeHUD(hudAnchor);
-          }
-        }
-      }
+    const roadGroup = this.meshes.get(object.id) as THREE.Group | undefined;
+    if (!roadGroup || !object.data?.roadSegments) {
+      return;
     }
+
+    const currentSegments = this.roadSegments.get(object.id);
+    const newSegments = object.data.roadSegments;
+    const segmentStates = object.data?.segmentStates || [];
+
+    if (!this.segmentsEqual(currentSegments, newSegments) || this.segmentStatesChanged(object.id, segmentStates)) {
+      this.remove(object.id);
+      this.render(object);
+      return;
+    }
+
+    const fallbackTotal = Array.isArray(newSegments) ? newSegments.length : 0;
+    const info = this.buildRoadResourceInfo(object, fallbackTotal);
+    const isFullyBuilt = !!object.data?.built;
+
+    if (!info) {
+      this.removeRoadHUD(roadGroup, object.id);
+      return;
+    }
+
+    const shouldShowHud =
+      info.segmentsTotal > 0 &&
+      !isFullyBuilt &&
+      (info.progress < 1 || info.segmentsBuilt < info.segmentsTotal);
+
+    if (!shouldShowHud) {
+      this.removeRoadHUD(roadGroup, object.id);
+      return;
+    }
+
+    const first = (newSegments as RoadSegment[])[0];
+    if (!first) {
+      this.removeRoadHUD(roadGroup, object.id);
+      return;
+    }
+
+    const c0 = new THREE.Vector3().addVectors(first.startLeft, first.startRight).multiplyScalar(0.5);
+    const c1 = new THREE.Vector3().addVectors(first.endLeft, first.endRight).multiplyScalar(0.5);
+    const head = new THREE.Vector3().addVectors(c0, c1).multiplyScalar(0.5);
+
+    let hudAnchor = roadGroup.getObjectByName('hudAnchor') as THREE.Object3D | null;
+    if (!hudAnchor) {
+      hudAnchor = new THREE.Object3D();
+      hudAnchor.name = 'hudAnchor';
+      roadGroup.add(hudAnchor);
+    }
+    hudAnchor.position.copy(head);
+
+    const signature = this.createHudSignature(info);
+    const prevSignature = this.hudSignatures.get(object.id);
+    const hasHud = Boolean((hudAnchor as any).userData?.combinedHUD);
+
+    if (hasHud && prevSignature === signature) {
+      return;
+    }
+
+    this.hudSignatures.set(object.id, signature);
+    const title = `Segments: ${info.segmentsBuilt}/${info.segmentsTotal}`;
+    this.attachOrUpdateCombinedHUD(object.id, hudAnchor, info.progress, info, 0.6, 1, { title });
+  }
+
+  public override remove(id: string): void {
+    super.remove(id);
+    this.roadSegments.delete(id);
+    this.lastSegmentStates.delete(id);
+    this.hudSignatures.delete(id);
   }
 
   private segmentsEqual(segments1?: RoadSegment[], segments2?: RoadSegment[]): boolean {
@@ -316,8 +364,6 @@ export class RoadRenderer extends BaseRenderer {
              lastState?.constructionProgress !== newState?.constructionProgress;
     });
 
-    console.log('hasChanged: ', hasChanged, newStates.map((s,i) => `${i}:${s.id}:${s.buildingState}`).toString(), lastStates.map((s,i) => `${i}:${s.id}:${s.buildingState}`).toString());
-    
     // ВАЖЛИВО: оновлюємо кеш ТІЛЬКИ якщо є зміни
     if (hasChanged) {
       this.lastSegmentStates.set(roadId, newStates.map(s => ({ ...s })));
@@ -331,24 +377,29 @@ export class RoadRenderer extends BaseRenderer {
    */
   public removeRoad(roadId: string): void {
     this.remove(roadId);
-    this.roadSegments.delete(roadId);
-    this.lastSegmentStates.delete(roadId);
   }
 
   /**
    * Очищає всі дороги
    */
   public clearAllRoads(): void {
-    for (const roadId of this.roadSegments.keys()) {
+    for (const roadId of Array.from(this.roadSegments.keys())) {
       this.remove(roadId);
     }
     this.roadSegments.clear();
+    this.lastSegmentStates.clear();
+    this.hudSignatures.clear();
   }
 
   public dispose(): void {
     super.dispose();
     this.roadSegments.clear();
-    
+    this.lastSegmentStates.clear();
+    this.hudSignatures.clear();
+    this.cachedCanvasTexture?.dispose?.();
+    this.cachedCanvasTexture = null;
+    this.lastCanvasUpdate = 0;
+
     // Очищаємо матеріали
     if (this.roadMaterial) {
       this.roadMaterial.dispose();
@@ -360,6 +411,7 @@ export class RoadRenderer extends BaseRenderer {
 
   // ---------- Combined HUD (mirrors BuildingRenderer) ----------
   private attachOrUpdateCombinedHUD(
+    ownerId: string,
     anchor: THREE.Object3D,
     constructionProgress: number,
     resourceInfo: { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; },
@@ -419,11 +471,10 @@ export class RoadRenderer extends BaseRenderer {
           final = Math.min(final, pxScale);
         }
         hud!.scale.set(final, final, final);
+        hud!.updateMatrixWorld(true);
       };
 
-      this.scene.add(hud);
-      (anchor as any).userData = (anchor as any).userData || {};
-      (anchor as any).userData.combinedHUD = hud;
+      this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
@@ -437,37 +488,12 @@ export class RoadRenderer extends BaseRenderer {
     }
   }
 
-  private removeHUD(anchor: THREE.Object3D): void {
-    const hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    console.log(`[RoadRenderer.removeHUD] Anchor:`, anchor.name, `HUD found:`, !!hud);
-    if (hud) { 
-      // Видаляємо HUD зі сцени
-      this.scene.remove(hud);
-      
-      // Також робимо невидимим на всякий випадок
-      hud.visible = false;
-      
-      // Очищаємо всі дочірні об'єкти HUD
-      hud.clear();
-      
-      // Видаляємо матеріали та геометрії
-      hud.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
-          if (child.geometry) child.geometry.dispose();
-          if (child.material) {
-            if (Array.isArray(child.material)) {
-              child.material.forEach(mat => mat.dispose());
-            } else {
-              child.material.dispose();
-            }
-          }
-        }
-      });
-      
-      // Очищаємо посилання
-      (anchor as any).userData.combinedHUD = undefined;
-      console.log(`[RoadRenderer.removeHUD] HUD removed from scene and disposed`);
+  private removeRoadHUD(group: THREE.Object3D, roadId: string): void {
+    const hudAnchor = group.getObjectByName('hudAnchor') as THREE.Object3D | null;
+    if (hudAnchor) {
+      this.hudRegistry.detachFromAnchor(hudAnchor);
     }
+    this.hudSignatures.delete(roadId);
   }
 
   
@@ -479,36 +505,36 @@ export class RoadRenderer extends BaseRenderer {
     const showProgress = options?.showProgress !== false;
   
     const now = Date.now();
-    if (!options?.disableCache && now - (this as any).lastCanvasUpdate < 200) {
+    if (!options?.disableCache && now - this.lastCanvasUpdate < this.CANVAS_UPDATE_THROTTLE_MS) {
       const { texture } = this.getCachedCanvasTexture();
       return { texture, aspect: this.lastAspect, contentHeightWorld: this.lastContentHeightWorld };
     }
-    (this as any).lastCanvasUpdate = now;
+    this.lastCanvasUpdate = now;
   
     // БІЛЬШИЙ ТАРГЕТНИЙ РОЗМІР + без *1.5 (який зменшував ефективний розмір після clamp)
     const rendererDpr = (this as any).renderer?.getPixelRatio?.() ?? (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1;
     const dpr = rendererDpr * this.INTERNAL_SCALE;
   
     // UI розміри в CSS-пікселях (до множення на dpr)
-    const TITLE_PX = 18;
-    const NAME_PX  = 20;
-    const QTY_PX   = 18;
-    const ROW_H    = this.ROW_HEIGHT_PX;      // 28
-    const PROG_H   = this.PROGRESS_HEIGHT_PX; // 5
-  
+    const TITLE_PX = 27;
+    const NAME_PX  = 30;
+    const QTY_PX   = 27;
+    const ROW_H    = this.ROW_HEIGHT_PX;      // 42
+    const PROG_H   = this.PROGRESS_HEIGHT_PX; // 7.5
+
     // Функція "px → dev px"
     const px = (v: number) => Math.round(v * dpr);
-  
+
     const rows = Math.max(1, Object.keys(resourceInfo.required).length);
-    const pad = px(12);
-    const vGap = px(10);
-    const sidePad = px(this.SIDE_PAD_PX);   // 16
-    const gapS = px(this.GAP_SMALL_PX);     // 8
-    const gapM = px(this.GAP_MEDIUM_PX);    // 12
-    const iconSize = px(this.ICON_SIZE_PX); // 24
-    const reqColW = px(this.REQ_COL_W_PX);  // 42
-    const barH = px(this.BAR_HEIGHT_PX + 2);
-    const titleH = options?.title ? px(TITLE_PX + 2) : 0;
+    const pad = px(18);
+    const vGap = px(15);
+    const sidePad = px(this.SIDE_PAD_PX);   // 24
+    const gapS = px(this.GAP_SMALL_PX);     // 12
+    const gapM = px(this.GAP_MEDIUM_PX);    // 18
+    const iconSize = px(this.ICON_SIZE_PX); // 36
+    const reqColW = px(this.REQ_COL_W_PX);  // 63
+    const barH = px(this.BAR_HEIGHT_PX + 3);
+    const titleH = options?.title ? px(TITLE_PX + 3) : 0;
     const progressH = showProgress ? px(PROG_H) : 0;
   
     // ---------- PASS 1: вимірюємо текст, рахуємо мінімально потрібну ширину ----------
@@ -522,13 +548,13 @@ export class RoadRenderer extends BaseRenderer {
       longestNamePx = Math.max(longestNamePx, Math.ceil(sctx.measureText(name).width));
     }
   
-    const NAME_MIN_W = px(this.NAME_MIN_W_PX);      // 110*dpr
-    const NAME_MAX_W = px(220);                     // жорстка “стеля”, щоб не роздувати HUD
+    const NAME_MIN_W = px(this.NAME_MIN_W_PX);      // 165*dpr
+    const NAME_MAX_W = px(330);                     // жорстка “стеля”, щоб не роздувати HUD
     let nameColW = Math.max(NAME_MIN_W, Math.min(longestNamePx, NAME_MAX_W));
-  
-    const BAR_MIN_W = px(this.BAR_MIN_W_PX);        // 50*dpr
-    const BAR_MAX_W = px(this.BAR_MAX_W_PX);        // 120*dpr
-    const barW = Math.max(BAR_MIN_W, Math.min(BAR_MAX_W, px(120)));
+
+    const BAR_MIN_W = px(this.BAR_MIN_W_PX);        // 75*dpr
+    const BAR_MAX_W = px(this.BAR_MAX_W_PX);        // 180*dpr
+    const barW = Math.max(BAR_MIN_W, Math.min(BAR_MAX_W, px(180)));
   
     // Загальна ширина контенту без урахування safe-fraction/crop
     const contentW =
@@ -540,7 +566,7 @@ export class RoadRenderer extends BaseRenderer {
     const heightRaw = pad + titleBlock + progressBlock + rows * px(ROW_H) + pad;
   
     // Робимо невеличкий буфер по ширині, але без гігантського 1224
-    const widthRaw = Math.max(px(420), contentW);
+    const widthRaw = Math.max(px(630), contentW);
   
     // Підженемо під power-of-two (з теґом кріспності)
     const toPOT = (v: number) => THREE.MathUtils.ceilPowerOfTwo(Math.max(2, v));
@@ -573,7 +599,7 @@ export class RoadRenderer extends BaseRenderer {
       ctx.font = `${px(TITLE_PX)}px Inter, Arial, sans-serif`;
       ctx.fillStyle = '#ffffff';
       ctx.textAlign = 'left';
-      ctx.fillText(options.title, contentLeft, cursorTop + px(2));
+      ctx.fillText(options.title, contentLeft, cursorTop + px(3));
       cursorTop += titleH + vGap;
     }
   
@@ -583,14 +609,14 @@ export class RoadRenderer extends BaseRenderer {
       const progressW = Math.max(1, contentRight - contentLeft);
       const progressY = cursorTop;
       ctx.fillStyle = 'rgba(255,255,255,0.18)';
-      ctx.fillRect(progressX - px(2), progressY - px(2), progressW + px(4), progressH + px(4));
+      ctx.fillRect(progressX - px(3), progressY - px(3), progressW + px(6), progressH + px(6));
       ctx.fillStyle = 'rgba(255,255,255,0.12)';
       ctx.fillRect(progressX, progressY, progressW, progressH);
       ctx.fillStyle = '#12d06b';
       ctx.fillRect(
         progressX,
         progressY,
-        Math.max(px(6), Math.round(progressW * THREE.MathUtils.clamp(resourceInfo.progress, 0, 1))),
+        Math.max(px(9), Math.round(progressW * THREE.MathUtils.clamp(resourceInfo.progress, 0, 1))),
         progressH
       );
       cursorTop += progressH + vGap;
@@ -611,7 +637,7 @@ export class RoadRenderer extends BaseRenderer {
       ctx.font = nameFont;
       ctx.fillStyle = '#ffffff';
       ctx.textAlign = 'left';
-      ctx.fillText(resourceId, nameX, rowCenterY + px(1));
+      ctx.fillText(resourceId, nameX, rowCenterY + px(1.5));
   
       // Бар
       const got = resourceInfo.collected[resourceId] || 0;
@@ -619,11 +645,11 @@ export class RoadRenderer extends BaseRenderer {
       const p = reqAmt > 0 ? Math.max(0, Math.min(1, got / reqAmt)) : 1;
       const bY = rowCenterY - Math.round(barH / 2);
       ctx.fillStyle = 'rgba(255,255,255,0.20)';
-      ctx.fillRect(barX - px(2), bY - px(2), barW + px(4), barH + px(4));
+      ctx.fillRect(barX - px(3), bY - px(3), barW + px(6), barH + px(6));
       ctx.fillStyle = 'rgba(255,255,255,0.12)';
       ctx.fillRect(barX, bY, barW, barH);
       ctx.fillStyle = done ? '#12d06b' : '#ff4444';
-      ctx.fillRect(barX, bY, Math.max(px(6), Math.round(barW * p)), barH);
+      ctx.fillRect(barX, bY, Math.max(px(9), Math.round(barW * p)), barH);
   
       // Кількість
       ctx.font = qtyFont;
@@ -674,25 +700,117 @@ export class RoadRenderer extends BaseRenderer {
     const predictedWidthPx = targetHeightPx * aspect; if (predictedWidthPx <= 0) return baseScale; const widthClamp = Math.max(1e-6, maxWidthPx / predictedWidthPx); return Math.min(baseScale, widthClamp * baseScale);
   }
 
-  // Convert road aggregates to ResourceInfo-like shape
-  private getRoadResourceInfo(roadId: string): { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; } | null {
-    if (!this.uiLogicBridge) return null;
-    const aggr = this.uiLogicBridge.getRoadAggregates(roadId);
-    if (!aggr) return null;
-    
-    // DEBUG: Логуємо що повертає getRoadAggregates
-    console.log(`[RoadRenderer.getRoadResourceInfo] Road ${roadId}:`, {
-      builtSegments: aggr.builtSegments,
-      totalSegments: aggr.totalSegments,
-      totalRequired: aggr.totalRequired,
-      totalDelivered: aggr.totalDelivered
-    });
-    const required = { ...aggr.totalRequired };
-    const collected = { ...aggr.totalDelivered };
+  // Build HUD resource info by combining segment states with optional manager aggregates
+  private buildRoadResourceInfo(object: TSceneObject, fallbackSegmentsTotal = 0): RoadHudInfo | null {
+    const segmentStates = (object.data?.segmentStates as any[]) ?? [];
+    const aggregates = this.uiLogicBridge?.getRoadAggregates(object.id) ?? null;
+
+    if (!segmentStates.length && !aggregates) {
+      return null;
+    }
+
+    const requiredTotals: Record<string, number> = {};
+    const deliveredTotals: Record<string, number> = {};
+    let segmentsBuiltFromStates = 0;
+    let segmentsTotal = segmentStates.length;
+
+    for (const state of segmentStates) {
+      if (!state) continue;
+
+      const builtFlag = state.buildingState === 'completed' || state.built === true;
+      const progressFlag = typeof state.constructionProgress === 'number' && state.constructionProgress >= 1;
+      if (builtFlag || progressFlag) {
+        segmentsBuiltFromStates += 1;
+      }
+
+      const required = state.requiredResources ?? {};
+      for (const [resource, amount] of Object.entries(required)) {
+        const reqVal = Math.max(0, Number(amount) || 0);
+        requiredTotals[resource] = (requiredTotals[resource] ?? 0) + reqVal;
+      }
+
+      const delivered = state.deliveredResources ?? {};
+      for (const [resource, amount] of Object.entries(delivered)) {
+        const deliveredVal = Math.max(0, Number(amount) || 0);
+        deliveredTotals[resource] = (deliveredTotals[resource] ?? 0) + deliveredVal;
+      }
+    }
+
+    if (aggregates) {
+      segmentsTotal = Math.max(segmentsTotal, aggregates.totalSegments ?? 0);
+      segmentsBuiltFromStates = Math.max(segmentsBuiltFromStates, aggregates.builtSegments ?? 0);
+
+      for (const [resource, amount] of Object.entries(aggregates.totalRequired ?? {})) {
+        const reqVal = Math.max(0, Number(amount) || 0);
+        requiredTotals[resource] = Math.max(requiredTotals[resource] ?? 0, reqVal);
+      }
+
+      for (const [resource, amount] of Object.entries(aggregates.totalDelivered ?? {})) {
+        const deliveredVal = Math.max(0, Number(amount) || 0);
+        deliveredTotals[resource] = Math.max(deliveredTotals[resource] ?? 0, deliveredVal);
+      }
+    }
+
+    segmentsTotal = Math.max(segmentsTotal, fallbackSegmentsTotal);
+
+    if (segmentsTotal === 0) {
+      return null;
+    }
+
+    const required: Record<string, number> = {};
+    const collected: Record<string, number> = {};
     const missing: Record<string, number> = {};
-    let sumReq = 0, sumGot = 0;
-    for (const [k, v] of Object.entries(required)) { const got = collected[k] || 0; sumReq += v; sumGot += Math.min(v, got); if (got < v) missing[k] = v - got; }
-    const progress = sumReq > 0 ? sumGot / sumReq : 0;
-    return { required, collected, missing, progress, segmentsBuilt: aggr.builtSegments, segmentsTotal: aggr.totalSegments };
+    let totalRequired = 0;
+    let totalCollected = 0;
+
+    const resourceKeys = new Set<string>([
+      ...Object.keys(requiredTotals),
+      ...Object.keys(deliveredTotals)
+    ]);
+
+    for (const resource of resourceKeys) {
+      const requiredRaw = requiredTotals[resource] ?? 0;
+      const deliveredRaw = deliveredTotals[resource] ?? 0;
+      const reqVal = Math.max(0, Math.round(requiredRaw));
+      const deliveredVal = Math.max(0, Math.round(deliveredRaw));
+
+      if (reqVal === 0 && deliveredVal === 0) {
+        continue;
+      }
+
+      required[resource] = reqVal;
+      const clamped = Math.min(reqVal, deliveredVal);
+      collected[resource] = clamped;
+      totalRequired += reqVal;
+      totalCollected += clamped;
+
+      if (clamped < reqVal) {
+        missing[resource] = reqVal - clamped;
+      }
+    }
+
+    const progress = totalRequired > 0 ? Math.min(1, totalCollected / totalRequired) : 0;
+
+    return {
+      required,
+      collected,
+      missing,
+      progress,
+      segmentsBuilt: Math.min(segmentsBuiltFromStates, segmentsTotal),
+      segmentsTotal
+    };
+  }
+
+  private createHudSignature(info: RoadHudInfo): string {
+    const resources = Object.keys(info.required).sort();
+    const resourcePart = resources
+      .map((resource) => `${resource}:${info.required[resource]}:${info.collected[resource] ?? 0}`)
+      .join(',');
+
+    return [
+      `p:${info.progress.toFixed(4)}`,
+      `seg:${info.segmentsBuilt}/${info.segmentsTotal}`,
+      `res:${resourcePart}`
+    ].join('|');
   }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
@@ -2,6 +2,9 @@ import * as THREE from 'three';
 import { BaseRenderer } from './BaseRenderer';
 import { UiLogicBridge } from '@ui/logic/UiLogicBridge';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
+import { HudCanvasBuilder, ROAD_HUD_STYLE } from './hud/HudCanvasBuilder';
+import type { HudCanvasRequest, HudResourceEntry } from './hud/HudCanvasBuilder';
+import { clampScaleByWidth, computeScreenSpaceScale } from './hud/hudMath';
 
 interface RoadSegment {
   startLeft: THREE.Vector3;
@@ -20,6 +23,13 @@ interface RoadHudInfo {
   segmentsTotal: number;
 }
 
+const HUD_WORLD_Z_OFFSET = 0.035;
+const _hudQuat = new THREE.Quaternion();
+const _hudViewDir = new THREE.Vector3();
+const _hudWorldPos = new THREE.Vector3();
+const _hudLocalOffset = new THREE.Vector3();
+const _hudWorldScale = new THREE.Vector3();
+
 export class RoadRenderer extends BaseRenderer {
   private roadMaterial: THREE.Material;
   private plannedRoadMaterial: THREE.Material;
@@ -27,37 +37,15 @@ export class RoadRenderer extends BaseRenderer {
   private uiLogicBridge: UiLogicBridge | null = null;
 
   // HUD helpers (mirrors BuildingRenderer pattern)
-  private cachedCanvasTexture: THREE.CanvasTexture | null = null;
-  private lastAspect = 1;
-  private lastContentHeightWorld = 1;
-  private readonly CANVAS_UPDATE_THROTTLE_MS = 200;
-  private lastCanvasUpdate = 0;
+  private readonly hudStyle = ROAD_HUD_STYLE;
+  private readonly hudBuilder: HudCanvasBuilder;
   private hudSignatures: Map<string, string> = new Map();
-
-  // For roads use full canvas width to avoid left cropping
-  private readonly HUD_SAFE_FRACTION = 1.0;
-  private readonly HUD_CROP_X = 1.0;
-  private readonly HUD_WORLD_Z_OFFSET = 0.035;
-
-  private readonly PROGRESS_HEIGHT_PX = 7.5;
-  private readonly ROW_HEIGHT_PX = 42;
-  private readonly ICON_SIZE_PX = 36;
-  private readonly BAR_MIN_W_PX = 75;
-  private readonly BAR_HEIGHT_PX = 6;
-  private readonly SIDE_PAD_PX = 24;
-  private readonly GAP_SMALL_PX = 12;
-  private readonly GAP_MEDIUM_PX = 18;
-
-  private readonly HUD_TARGET_PX = { resourceHeight: 126, minScale: 0.1, maxScale: 100.0, maxWidth: 420 } as const;
-  private readonly NAME_MIN_W_PX = 165;
-  private readonly BAR_MAX_W_PX = 180;
-  private readonly REQ_COL_W_PX = 63;
-  private readonly INTERNAL_SCALE = 2;
 
   constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
     super(scene, renderer);
     this.roadMaterial = this.createRoadMaterial();
     this.plannedRoadMaterial = this.createPlannedRoadMaterial();
+    this.hudBuilder = new HudCanvasBuilder(renderer, this.hudStyle);
   }
 
   public setUiLogicBridge(bridge: UiLogicBridge): void {
@@ -392,13 +380,12 @@ export class RoadRenderer extends BaseRenderer {
   }
 
   public dispose(): void {
-    super.dispose();
     this.roadSegments.clear();
     this.lastSegmentStates.clear();
     this.hudSignatures.clear();
-    this.cachedCanvasTexture?.dispose?.();
-    this.cachedCanvasTexture = null;
-    this.lastCanvasUpdate = 0;
+    this.hudBuilder.dispose();
+
+    super.dispose();
 
     // Очищаємо матеріали
     if (this.roadMaterial) {
@@ -419,72 +406,94 @@ export class RoadRenderer extends BaseRenderer {
     baseParentScale: number,
     options?: { showProgress?: boolean; disableCache?: boolean; title?: string }
   ): void {
+    const request = this.createHudRequest(constructionProgress, resourceInfo, {
+      showProgress: options?.showProgress,
+      title: options?.title,
+    });
+
+    const { texture, aspect, contentHeightWorld, cropX } = this.hudBuilder.build(request, {
+      disableCache: options?.disableCache,
+    });
+
+    const planeH = contentHeightWorld;
+    const planeW = contentHeightWorld * aspect * cropX;
+
     let hud = (anchor as any).userData?.combinedHUD as THREE.Group | undefined;
-    const { texture, aspect, contentHeightWorld } = this.buildCombinedCanvasTexture(constructionProgress, resourceInfo, options);
-    const baseW = contentHeightWorld * aspect;
-    const baseH = contentHeightWorld;
-    const cropX = this.HUD_CROP_X;
-    const planeW = baseW * cropX;
-    const planeH = baseH;
 
     if (!hud) {
       hud = new THREE.Group();
       hud.name = 'combinedHUD';
       hud.renderOrder = 1100;
       hud.frustumCulled = false;
-      const bg = new THREE.Mesh(
-        new THREE.PlaneGeometry(planeW, planeH),
-        new THREE.MeshBasicMaterial({ map: texture, transparent: true, opacity: 1.0, side: THREE.DoubleSide, toneMapped: false, fog: false, depthTest: false, depthWrite: false })
-      );
+
+      const material = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+        opacity: 1.0,
+        side: THREE.DoubleSide,
+        toneMapped: false,
+        fog: false,
+        depthTest: false,
+        depthWrite: false,
+      });
+
+      const bg = new THREE.Mesh(new THREE.PlaneGeometry(planeW, planeH), material);
       bg.name = 'hudPlane';
-      if ((bg.material as THREE.MeshBasicMaterial).map) {
-        const map = (bg.material as THREE.MeshBasicMaterial).map!;
-        map.wrapS = THREE.ClampToEdgeWrapping; map.wrapT = THREE.ClampToEdgeWrapping;
-        map.repeat.set(cropX, 1); map.offset.set((1 - cropX) * 0.5, 0); map.needsUpdate = true;
-      }
-      hud.add(bg);
+      bg.frustumCulled = false;
+      this.applyHudTextureCrop(material, cropX);
 
-      const rendererRef = (this as any).renderer as THREE.WebGLRenderer | undefined;
-      const _qCam = new THREE.Quaternion();
-      const _viewDir = new THREE.Vector3();
-      const _worldPos = new THREE.Vector3();
-      const _localOffset = new THREE.Vector3();
-      const _worldScale = new THREE.Vector3();
-
+      const rendererRef = this.renderer;
       (bg as any).onBeforeRender = (_r: any, _s: any, camera: THREE.Camera) => {
         const extraY = (anchor as any).userData?.hudYOffset ?? 0;
-        _localOffset.set(0, barY + extraY, 0);
-        anchor.updateWorldMatrix(true, false);
-        anchor.localToWorld(_worldPos.copy(_localOffset));
-        (camera as any).getWorldQuaternion?.(_qCam) ?? _qCam.identity();
-        hud!.quaternion.copy(_qCam);
-        (camera as any).getWorldDirection?.(_viewDir) ?? _viewDir.set(0, 0, -1).applyQuaternion(_qCam);
-        const pos = _worldPos.clone().addScaledVector(_viewDir, -this.HUD_WORLD_Z_OFFSET);
-        hud!.position.copy(pos);
 
-        anchor.getWorldScale(_worldScale);
+        _hudLocalOffset.set(0, barY + extraY, 0);
+        anchor.updateWorldMatrix(true, false);
+        anchor.localToWorld(_hudWorldPos.copy(_hudLocalOffset));
+
+        (camera as THREE.Object3D).getWorldQuaternion(_hudQuat);
+        hud!.quaternion.copy(_hudQuat);
+
+        (camera as any).getWorldDirection?.(_hudViewDir) ?? _hudViewDir.set(0, 0, -1).applyQuaternion(_hudQuat);
+        hud!.position.copy(_hudWorldPos).addScaledVector(_hudViewDir, -HUD_WORLD_Z_OFFSET);
+
+        anchor.getWorldScale(_hudWorldScale);
         const base = 1 / Math.max(baseParentScale, 1e-6);
-        const screenS = this.computeScreenSpaceScale(camera, hud!.position, planeH, Math.round(this.HUD_TARGET_PX.resourceHeight), rendererRef);
-        let final = base * screenS;
-        if (rendererRef) {
-          const pxScale = this.computeWidthClampScale(camera, hud!.position, planeH, Math.round(this.HUD_TARGET_PX.resourceHeight), planeW / planeH, this.HUD_TARGET_PX.maxWidth, rendererRef);
-          final = Math.min(final, pxScale);
-        }
+        const planeAspect = planeW / Math.max(1e-6, planeH);
+
+        const screenScale = computeScreenSpaceScale(
+          camera,
+          hud!.position,
+          planeH,
+          this.hudStyle.targetHeightPx,
+          rendererRef,
+          this.hudStyle.minScale,
+          this.hudStyle.maxScale
+        );
+
+        let final = base * screenScale;
+        final = clampScaleByWidth(final, planeAspect, this.hudStyle.targetHeightPx, this.hudStyle.maxWidthPx);
+
         hud!.scale.set(final, final, final);
         hud!.updateMatrixWorld(true);
       };
 
+      hud.add(bg);
       this.hudRegistry.register(ownerId, anchor, hud);
     } else {
       const bg = hud.getObjectByName('hudPlane') as THREE.Mesh;
       const mat = bg.material as THREE.MeshBasicMaterial;
-      mat.map?.dispose(); mat.map = texture; mat.needsUpdate = true;
+      mat.map?.dispose();
+      mat.map = texture;
+      mat.needsUpdate = true;
+
       const geo = bg.geometry as THREE.PlaneGeometry;
       const params = geo.parameters;
       if (params.width !== planeW || params.height !== planeH) {
-        bg.geometry.dispose(); bg.geometry = new THREE.PlaneGeometry(planeW, planeH);
+        bg.geometry.dispose();
+        bg.geometry = new THREE.PlaneGeometry(planeW, planeH);
       }
-      if (mat.map) { mat.map.wrapS = THREE.ClampToEdgeWrapping; mat.map.wrapT = THREE.ClampToEdgeWrapping; mat.map.repeat.set(cropX, 1); mat.map.offset.set((1 - cropX) * 0.5, 0); mat.needsUpdate = true; }
+
+      this.applyHudTextureCrop(mat, cropX);
     }
   }
 
@@ -497,207 +506,42 @@ export class RoadRenderer extends BaseRenderer {
   }
 
   
-  private buildCombinedCanvasTexture(
-    constructionProgress: number,
-    resourceInfo: { required: Record<string, number>; collected: Record<string, number>; missing: Record<string, number>; progress: number; segmentsBuilt: number; segmentsTotal: number; },
-    options?: { showProgress?: boolean; disableCache?: boolean; title?: string }
-  ): { texture: THREE.CanvasTexture; aspect: number; contentHeightWorld: number } {
+
+  private applyHudTextureCrop(material: THREE.MeshBasicMaterial, cropX: number): void {
+    const map = material.map;
+    if (!map) return;
+
+    map.wrapS = THREE.ClampToEdgeWrapping;
+    map.wrapT = THREE.ClampToEdgeWrapping;
+    map.repeat.set(cropX, 1);
+    map.offset.set((1 - cropX) * 0.5, 0);
+    map.needsUpdate = true;
+  }
+
+  private createHudRequest(
+    progress: number,
+    info: RoadHudInfo,
+    options?: { showProgress?: boolean; title?: string }
+  ): HudCanvasRequest {
+    const ids = new Set<string>([
+      ...Object.keys(info.required || {}),
+      ...Object.keys(info.collected || {}),
+    ]);
+
+    const resources: HudResourceEntry[] = Array.from(ids).map((id) => ({
+      id,
+      required: info.required[id] ?? 0,
+      collected: info.collected[id] ?? 0,
+    }));
+
     const showProgress = options?.showProgress !== false;
-  
-    const now = Date.now();
-    if (!options?.disableCache && now - this.lastCanvasUpdate < this.CANVAS_UPDATE_THROTTLE_MS) {
-      const { texture } = this.getCachedCanvasTexture();
-      return { texture, aspect: this.lastAspect, contentHeightWorld: this.lastContentHeightWorld };
-    }
-    this.lastCanvasUpdate = now;
-  
-    // БІЛЬШИЙ ТАРГЕТНИЙ РОЗМІР + без *1.5 (який зменшував ефективний розмір після clamp)
-    const rendererDpr = (this as any).renderer?.getPixelRatio?.() ?? (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1;
-    const dpr = rendererDpr * this.INTERNAL_SCALE;
-  
-    // UI розміри в CSS-пікселях (до множення на dpr)
-    const TITLE_PX = 27;
-    const NAME_PX  = 30;
-    const QTY_PX   = 27;
-    const ROW_H    = this.ROW_HEIGHT_PX;      // 42
-    const PROG_H   = this.PROGRESS_HEIGHT_PX; // 7.5
 
-    // Функція "px → dev px"
-    const px = (v: number) => Math.round(v * dpr);
-
-    const rows = Math.max(1, Object.keys(resourceInfo.required).length);
-    const pad = px(18);
-    const vGap = px(15);
-    const sidePad = px(this.SIDE_PAD_PX);   // 24
-    const gapS = px(this.GAP_SMALL_PX);     // 12
-    const gapM = px(this.GAP_MEDIUM_PX);    // 18
-    const iconSize = px(this.ICON_SIZE_PX); // 36
-    const reqColW = px(this.REQ_COL_W_PX);  // 63
-    const barH = px(this.BAR_HEIGHT_PX + 3);
-    const titleH = options?.title ? px(TITLE_PX + 3) : 0;
-    const progressH = showProgress ? px(PROG_H) : 0;
-  
-    // ---------- PASS 1: вимірюємо текст, рахуємо мінімально потрібну ширину ----------
-    const scratch = document.createElement('canvas');
-    const sctx = scratch.getContext('2d')!;
-    sctx.textBaseline = 'alphabetic';
-    sctx.font = `${px(NAME_PX)}px Inter, Arial, sans-serif`;
-  
-    let longestNamePx = 0;
-    for (const name of Object.keys(resourceInfo.required)) {
-      longestNamePx = Math.max(longestNamePx, Math.ceil(sctx.measureText(name).width));
-    }
-  
-    const NAME_MIN_W = px(this.NAME_MIN_W_PX);      // 165*dpr
-    const NAME_MAX_W = px(330);                     // жорстка “стеля”, щоб не роздувати HUD
-    let nameColW = Math.max(NAME_MIN_W, Math.min(longestNamePx, NAME_MAX_W));
-
-    const BAR_MIN_W = px(this.BAR_MIN_W_PX);        // 75*dpr
-    const BAR_MAX_W = px(this.BAR_MAX_W_PX);        // 180*dpr
-    const barW = Math.max(BAR_MIN_W, Math.min(BAR_MAX_W, px(180)));
-  
-    // Загальна ширина контенту без урахування safe-fraction/crop
-    const contentW =
-      sidePad + iconSize + gapS + nameColW + gapM + barW + gapM + reqColW + sidePad;
-  
-    // Висота контенту
-    const progressBlock = showProgress ? (progressH + vGap) : 0;
-    const titleBlock = titleH ? (titleH + vGap) : 0;
-    const heightRaw = pad + titleBlock + progressBlock + rows * px(ROW_H) + pad;
-  
-    // Робимо невеличкий буфер по ширині, але без гігантського 1224
-    const widthRaw = Math.max(px(630), contentW);
-  
-    // Підженемо під power-of-two (з теґом кріспності)
-    const toPOT = (v: number) => THREE.MathUtils.ceilPowerOfTwo(Math.max(2, v));
-    const width  = toPOT(widthRaw);
-    const height = toPOT(heightRaw);
-  
-    // ---------- PASS 2: малюємо реальний канвас ----------
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d')!;
-  
-    // Фон
-    ctx.fillStyle = 'rgba(0,0,0,0.92)';
-    ctx.fillRect(0, 0, width, height);
-  
-    // Content bounds
-    const safeX = 0; // ми малюємо рівно під ширину контенту
-    const contentLeft = safeX + sidePad;
-    const contentRight = safeX + widthRaw - sidePad;
-  
-    // Тексти
-    const nameFont = `${px(NAME_PX)}px Inter, Arial, sans-serif`;
-    const qtyFont  = `${px(QTY_PX)}px Inter, Arial, sans-serif`;
-    ctx.textBaseline = 'middle';
-  
-    // Заголовок
-    let cursorTop = pad;
-    if (options?.title) {
-      ctx.font = `${px(TITLE_PX)}px Inter, Arial, sans-serif`;
-      ctx.fillStyle = '#ffffff';
-      ctx.textAlign = 'left';
-      ctx.fillText(options.title, contentLeft, cursorTop + px(3));
-      cursorTop += titleH + vGap;
-    }
-  
-    // Прогрес
-    if (showProgress) {
-      const progressX = contentLeft;
-      const progressW = Math.max(1, contentRight - contentLeft);
-      const progressY = cursorTop;
-      ctx.fillStyle = 'rgba(255,255,255,0.18)';
-      ctx.fillRect(progressX - px(3), progressY - px(3), progressW + px(6), progressH + px(6));
-      ctx.fillStyle = 'rgba(255,255,255,0.12)';
-      ctx.fillRect(progressX, progressY, progressW, progressH);
-      ctx.fillStyle = '#12d06b';
-      ctx.fillRect(
-        progressX,
-        progressY,
-        Math.max(px(9), Math.round(progressW * THREE.MathUtils.clamp(resourceInfo.progress, 0, 1))),
-        progressH
-      );
-      cursorTop += progressH + vGap;
-    }
-  
-    // Колонки
-    const iconX = contentLeft;
-    const nameX = iconX + iconSize + gapS;
-    const barX  = nameX + nameColW + gapM;
-    const reqX  = contentRight; // правий стовпчик чисел
-  
-    // Рядки ресурсів
-    let i = 0;
-    for (const [resourceId, reqAmt] of Object.entries(resourceInfo.required)) {
-      const rowCenterY = cursorTop + i * px(ROW_H) + Math.round(px(ROW_H) * 0.5);
-  
-      // Назва
-      ctx.font = nameFont;
-      ctx.fillStyle = '#ffffff';
-      ctx.textAlign = 'left';
-      ctx.fillText(resourceId, nameX, rowCenterY + px(1.5));
-  
-      // Бар
-      const got = resourceInfo.collected[resourceId] || 0;
-      const done = (reqAmt <= got);
-      const p = reqAmt > 0 ? Math.max(0, Math.min(1, got / reqAmt)) : 1;
-      const bY = rowCenterY - Math.round(barH / 2);
-      ctx.fillStyle = 'rgba(255,255,255,0.20)';
-      ctx.fillRect(barX - px(3), bY - px(3), barW + px(6), barH + px(6));
-      ctx.fillStyle = 'rgba(255,255,255,0.12)';
-      ctx.fillRect(barX, bY, barW, barH);
-      ctx.fillStyle = done ? '#12d06b' : '#ff4444';
-      ctx.fillRect(barX, bY, Math.max(px(9), Math.round(barW * p)), barH);
-  
-      // Кількість
-      ctx.font = qtyFont;
-      ctx.fillStyle = '#e6e6e6';
-      ctx.textAlign = 'right';
-      ctx.fillText(String(Math.round(reqAmt)), reqX, rowCenterY);
-  
-      i++;
-    }
-  
-    // Текстура
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.colorSpace = THREE.SRGBColorSpace;
-    texture.generateMipmaps = true;
-    texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.anisotropy = (this as any).renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
-    texture.needsUpdate = true;
-  
-    this.cachedCanvasTexture = texture;
-  
-    // Менше aspect → менше шансів потрапити під width-clamp
-    const aspect = widthRaw / heightRaw;
-    const contentHeightWorld = 1.0;
-    this.lastAspect = aspect;
-    this.lastContentHeightWorld = contentHeightWorld;
-  
-    return { texture, aspect, contentHeightWorld };
-  }
-  
-
-  private getCachedCanvasTexture(): { texture: THREE.CanvasTexture; aspect: number; contentHeightWorld: number } {
-    if (!this.cachedCanvasTexture) {
-      const canvas = document.createElement('canvas'); canvas.width = 2; canvas.height = 2; const tex = new THREE.CanvasTexture(canvas); tex.colorSpace = THREE.SRGBColorSpace; tex.generateMipmaps = false; tex.minFilter = THREE.LinearFilter; tex.magFilter = THREE.LinearFilter; this.cachedCanvasTexture = tex;
-    }
-    return { texture: this.cachedCanvasTexture, aspect: this.lastAspect, contentHeightWorld: this.lastContentHeightWorld };
-  }
-
-  private computeScreenSpaceScale(camera: THREE.Camera, worldPos: THREE.Vector3, planeWorldHeight: number, targetPx: number, renderer?: THREE.WebGLRenderer): number {
-    const size = renderer?.getSize(new THREE.Vector2()); const dpr = renderer?.getPixelRatio?.() ?? (typeof window !== 'undefined' ? window.devicePixelRatio : 1) ?? 1; const viewportH = (size?.y ?? (typeof window !== 'undefined' ? window.innerHeight : 800)) * dpr;
-    if ((camera as any).isOrthographicCamera) { const cam = camera as THREE.OrthographicCamera; const orthoHeight = Math.max(1e-6, cam.top - cam.bottom); const pxPerWorld = viewportH / orthoHeight; const currentPx = planeWorldHeight * pxPerWorld; const s = Math.round(targetPx) / Math.max(1e-6, currentPx); return THREE.MathUtils.clamp(s, this.HUD_TARGET_PX.minScale, this.HUD_TARGET_PX.maxScale); }
-    if ((camera as any).isPerspectiveCamera) { const _camPos = new THREE.Vector3(); (camera as THREE.Object3D).getWorldPosition(_camPos); const d = _camPos.distanceTo(worldPos); const cam = camera as THREE.PerspectiveCamera; const tan = Math.tan(THREE.MathUtils.degToRad(cam.fov) * 0.5); const denom = Math.max(1e-6, 2 * d * tan); const heightToPixels = viewportH / denom; const s = Math.round(targetPx) / Math.max(1e-6, planeWorldHeight * heightToPixels); return THREE.MathUtils.clamp(s, this.HUD_TARGET_PX.minScale, this.HUD_TARGET_PX.maxScale); }
-    return 1;
-  }
-
-  private computeWidthClampScale(camera: THREE.Camera, worldPos: THREE.Vector3, planeWorldHeight: number, targetHeightPx: number, aspect: number, maxWidthPx: number, renderer: THREE.WebGLRenderer): number {
-    const baseScale = this.computeScreenSpaceScale(camera, worldPos, planeWorldHeight, targetHeightPx, renderer);
-    const predictedWidthPx = targetHeightPx * aspect; if (predictedWidthPx <= 0) return baseScale; const widthClamp = Math.max(1e-6, maxWidthPx / predictedWidthPx); return Math.min(baseScale, widthClamp * baseScale);
+    return {
+      title: options?.title,
+      progress: showProgress ? THREE.MathUtils.clamp(progress ?? info.progress ?? 0, 0, 1) : 0,
+      showProgress,
+      resources,
+    };
   }
 
   // Build HUD resource info by combining segment states with optional manager aggregates

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudCanvasBuilder.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudCanvasBuilder.ts
@@ -64,24 +64,24 @@ const BASE_HUD_STYLE: HudStyle = {
   contentWorldHeight: 1,
   internalScale: 2,
   throttleMs: 180,
-  targetHeightPx: 84,
-  maxWidthPx: 420,
+  targetHeightPx: 96,
+  maxWidthPx: 240,
   minScale: 0.1,
   maxScale: 100,
   outerPaddingPx: 18,
-  titleFontPx: 26,
-  titleLineHeightPx: 32,
+  titleFontPx: 48,
+  titleLineHeightPx: 62,
   titleGapPx: 16,
   sectionGapPx: 18,
   progressHeightPx: 10,
   progressOutlinePaddingPx: 3,
   progressMinFillPx: 12,
-  rowHeightPx: 42,
-  iconSizePx: 36,
-  nameFontPx: 26,
+  rowHeightPx: 56,
+  iconSizePx: 46,
+  nameFontPx: 44,
   nameBaselineOffsetPx: 2,
-  qtyFontPx: 24,
-  nameMinWidthPx: 200,
+  qtyFontPx: 44,
+  nameMinWidthPx: 120,
   barMinWidthPx: 96,
   barMaxWidthPx: 260,
   barHeightPx: 8,
@@ -90,23 +90,23 @@ const BASE_HUD_STYLE: HudStyle = {
   sidePaddingPx: 24,
   gapSmallPx: 12,
   gapMediumPx: 18,
-  reqColumnWidthPx: 78,
+  reqColumnWidthPx: 50,
   minRows: 1,
 };
 
 export const BUILDING_HUD_STYLE: HudStyle = {
   ...BASE_HUD_STYLE,
-  titleFontPx: 28,
-  titleLineHeightPx: 34,
+  titleFontPx: 48,
+  titleLineHeightPx: 62,
   targetHeightPx: 84,
-  maxWidthPx: 420,
+  maxWidthPx: 240,
 };
 
 export const ROAD_HUD_STYLE: HudStyle = {
   ...BASE_HUD_STYLE,
-  titleFontPx: 24,
-  titleLineHeightPx: 30,
-  reqColumnWidthPx: 72,
+  titleFontPx: 48,
+  titleLineHeightPx: 62,
+  reqColumnWidthPx: 50,
 };
 
 export class HudCanvasBuilder {
@@ -288,6 +288,7 @@ export class HudCanvasBuilder {
       ctx.fillStyle = complete ? '#12d06b' : '#ffffff';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
+      console.log('NameData: ', nameMaxW, nameMin, nameX, gapMedium, barX, availableBetween);
       ctx.fillText(truncate(displayName, nameMaxW, nameFont), nameX, nameY);
 
       const barY = rowCenterY - Math.round(barHeight / 2);

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudCanvasBuilder.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudCanvasBuilder.ts
@@ -1,0 +1,383 @@
+import * as THREE from 'three';
+import { RESOURCES_DB, ResourceId } from '@logic/modules/resources/resources-db';
+import { ResourceIcons } from '../ResourceIcons';
+
+export interface HudResourceEntry {
+  id: string;
+  required: number;
+  collected: number;
+}
+
+export interface HudCanvasRequest {
+  title?: string;
+  progress: number;
+  showProgress: boolean;
+  resources: HudResourceEntry[];
+}
+
+export interface HudCanvasResult {
+  texture: THREE.CanvasTexture;
+  aspect: number;
+  contentHeightWorld: number;
+  cropX: number;
+}
+
+export interface HudStyle {
+  textureWidthPx: number;
+  safeHorizontalFraction: number;
+  contentWorldHeight: number;
+  internalScale: number;
+  throttleMs: number;
+  targetHeightPx: number;
+  maxWidthPx: number;
+  minScale: number;
+  maxScale: number;
+  outerPaddingPx: number;
+  titleFontPx: number;
+  titleLineHeightPx: number;
+  titleGapPx: number;
+  sectionGapPx: number;
+  progressHeightPx: number;
+  progressOutlinePaddingPx: number;
+  progressMinFillPx: number;
+  rowHeightPx: number;
+  iconSizePx: number;
+  nameFontPx: number;
+  nameBaselineOffsetPx: number;
+  qtyFontPx: number;
+  nameMinWidthPx: number;
+  barMinWidthPx: number;
+  barMaxWidthPx: number;
+  barHeightPx: number;
+  barOutlinePaddingPx: number;
+  barMinFillPx: number;
+  sidePaddingPx: number;
+  gapSmallPx: number;
+  gapMediumPx: number;
+  reqColumnWidthPx: number;
+  minRows?: number;
+}
+
+const BASE_HUD_STYLE: HudStyle = {
+  textureWidthPx: 1024,
+  safeHorizontalFraction: 1,
+  contentWorldHeight: 1,
+  internalScale: 2,
+  throttleMs: 180,
+  targetHeightPx: 84,
+  maxWidthPx: 420,
+  minScale: 0.1,
+  maxScale: 100,
+  outerPaddingPx: 18,
+  titleFontPx: 26,
+  titleLineHeightPx: 32,
+  titleGapPx: 16,
+  sectionGapPx: 18,
+  progressHeightPx: 10,
+  progressOutlinePaddingPx: 3,
+  progressMinFillPx: 12,
+  rowHeightPx: 42,
+  iconSizePx: 36,
+  nameFontPx: 26,
+  nameBaselineOffsetPx: 2,
+  qtyFontPx: 24,
+  nameMinWidthPx: 200,
+  barMinWidthPx: 96,
+  barMaxWidthPx: 260,
+  barHeightPx: 8,
+  barOutlinePaddingPx: 3,
+  barMinFillPx: 12,
+  sidePaddingPx: 24,
+  gapSmallPx: 12,
+  gapMediumPx: 18,
+  reqColumnWidthPx: 78,
+  minRows: 1,
+};
+
+export const BUILDING_HUD_STYLE: HudStyle = {
+  ...BASE_HUD_STYLE,
+  titleFontPx: 28,
+  titleLineHeightPx: 34,
+  targetHeightPx: 84,
+  maxWidthPx: 420,
+};
+
+export const ROAD_HUD_STYLE: HudStyle = {
+  ...BASE_HUD_STYLE,
+  titleFontPx: 24,
+  titleLineHeightPx: 30,
+  reqColumnWidthPx: 72,
+};
+
+export class HudCanvasBuilder {
+  private cachedCanvasTexture: THREE.CanvasTexture | null = null;
+  private lastAspect = 1;
+  private lastContentHeightWorld = 1;
+  private lastCropX = 1;
+  private lastCanvasUpdate = 0;
+
+  constructor(private renderer: THREE.WebGLRenderer | undefined, private readonly style: HudStyle) {}
+
+  build(request: HudCanvasRequest, options?: { disableCache?: boolean }): HudCanvasResult {
+    const showProgress = request.showProgress !== false;
+    const now = Date.now();
+    if (!options?.disableCache && this.cachedCanvasTexture && now - this.lastCanvasUpdate < this.style.throttleMs) {
+      return {
+        texture: this.cachedCanvasTexture,
+        aspect: this.lastAspect,
+        contentHeightWorld: this.lastContentHeightWorld,
+        cropX: this.lastCropX,
+      };
+    }
+    this.lastCanvasUpdate = now;
+
+    const dpr = this.computeDevicePixelRatio();
+    const px = (value: number) => Math.round(value * dpr);
+
+    const resources = this.normaliseResources(request.resources);
+    const rowsCount = Math.max(this.style.minRows ?? 0, resources.length);
+
+    const baseWidthPx = Math.max(2, this.style.textureWidthPx);
+    const widthRaw = Math.round(baseWidthPx * dpr);
+
+    const pad = px(this.style.outerPaddingPx);
+    const rowH = px(this.style.rowHeightPx);
+    const sectionGap = px(this.style.sectionGapPx);
+    const progressH = showProgress ? px(this.style.progressHeightPx) : 0;
+    const progressGap = showProgress ? sectionGap : 0;
+    const titleLineHeight = request.title ? px(this.style.titleLineHeightPx) : 0;
+    const titleGap = request.title ? px(this.style.titleGapPx) : 0;
+
+    const heightRaw = pad + titleLineHeight + titleGap + progressH + progressGap + rowsCount * rowH + pad;
+
+    const width = THREE.MathUtils.ceilPowerOfTwo(Math.max(2, widthRaw));
+    const height = THREE.MathUtils.ceilPowerOfTwo(Math.max(2, heightRaw));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Unable to acquire 2D context for HUD canvas');
+    }
+
+    ctx.imageSmoothingEnabled = true;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.9)';
+    ctx.fillRect(0, 0, width, height);
+
+    const texture = new THREE.CanvasTexture(canvas);
+
+    const safeFraction = THREE.MathUtils.clamp(this.style.safeHorizontalFraction, 0, 1);
+    const safeW = Math.round(widthRaw * safeFraction);
+    const safeX = Math.round((widthRaw - safeW) * 0.5);
+    const safeRight = safeX + safeW;
+
+    const contentLeft = safeX + px(this.style.sidePaddingPx);
+    const contentRight = safeRight - px(this.style.sidePaddingPx);
+
+    let cursorY = pad;
+
+    if (request.title) {
+      ctx.font = `${px(this.style.titleFontPx)}px Inter, Arial, sans-serif`;
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      ctx.fillText(request.title, contentLeft, cursorY);
+      cursorY += titleLineHeight + titleGap;
+    }
+
+    if (showProgress) {
+      const progressX = contentLeft;
+      const progressW = Math.max(1, contentRight - contentLeft);
+      const progressY = cursorY;
+      const outline = px(this.style.progressOutlinePaddingPx);
+      const minFill = px(this.style.progressMinFillPx);
+      const progress = THREE.MathUtils.clamp(request.progress ?? 0, 0, 1);
+
+      ctx.fillStyle = 'rgba(255,255,255,0.18)';
+      ctx.fillRect(progressX - outline, progressY - outline, progressW + outline * 2, progressH + outline * 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.12)';
+      ctx.fillRect(progressX, progressY, progressW, progressH);
+
+      const filled = Math.round(progressW * progress);
+      const fillWidth = progress <= 0 ? 0 : Math.max(minFill, filled);
+      if (fillWidth > 0) {
+        ctx.fillStyle = '#12d06b';
+        ctx.fillRect(progressX, progressY, Math.min(progressW, fillWidth), progressH);
+      }
+
+      cursorY += progressH + progressGap;
+    }
+
+    const gapSmall = px(this.style.gapSmallPx);
+    const gapMedium = px(this.style.gapMediumPx);
+    const iconSize = px(this.style.iconSizePx);
+    const iconX = contentLeft;
+    const nameX = iconX + iconSize + gapSmall;
+    const reqColumnWidth = px(this.style.reqColumnWidthPx);
+    const rightLimit = contentRight - reqColumnWidth;
+    const availableBetween = Math.max(0, rightLimit - nameX - gapMedium);
+
+    const nameMin = px(this.style.nameMinWidthPx);
+    const barMin = px(this.style.barMinWidthPx);
+    const barMax = px(this.style.barMaxWidthPx);
+    const barHeight = px(this.style.barHeightPx);
+    const barOutline = px(this.style.barOutlinePaddingPx);
+    const barMinFill = px(this.style.barMinFillPx);
+
+    const nameFont = `${px(this.style.nameFontPx)}px Inter, Arial, sans-serif`;
+    const qtyFont = `${px(this.style.qtyFontPx)}px Inter, Arial, sans-serif`;
+    const nameBaselineOffset = px(this.style.nameBaselineOffsetPx);
+
+    const truncate = (text: string, maxWidth: number, font: string) => {
+      ctx.font = font;
+      if (maxWidth <= 0) return '…';
+      if (ctx.measureText(text).width <= maxWidth) return text;
+      const ellipsis = '…';
+      let lo = 0;
+      let hi = text.length;
+      while (lo < hi) {
+        const mid = ((lo + hi) / 2) | 0;
+        const candidate = text.slice(0, mid) + ellipsis;
+        if (ctx.measureText(candidate).width <= maxWidth) lo = mid + 1; else hi = mid;
+      }
+      return text.slice(0, Math.max(0, lo - 1)) + ellipsis;
+    };
+
+    resources.forEach((resource, index) => {
+      const rowTop = cursorY + index * rowH;
+      const rowCenterY = rowTop + Math.round(rowH * 0.5);
+
+      let nameMaxW = Math.round(availableBetween * 0.55);
+      let barW = availableBetween - nameMaxW;
+
+      if (nameMaxW < nameMin) {
+        const deficit = nameMin - nameMaxW;
+        nameMaxW += deficit;
+        barW -= deficit;
+      }
+
+      if (barW < barMin) {
+        const deficit = barMin - barW;
+        barW += deficit;
+        nameMaxW -= deficit;
+      }
+
+      nameMaxW = Math.max(nameMin, nameMaxW);
+      barW = Math.min(barMax, Math.max(barMin, barW));
+
+      const barX = nameX + nameMaxW + gapMedium;
+      const reqX = contentRight;
+
+      const resourceMeta = RESOURCES_DB[resource.id as ResourceId];
+      const displayName = resourceMeta?.name ?? resource.id;
+      const baseColor = resourceMeta?.color ?? '#cccccc';
+
+      const required = Math.max(0, Number(resource.required) || 0);
+      const collectedRaw = Math.max(0, Number(resource.collected) || 0);
+      const collected = required > 0 ? Math.min(required, collectedRaw) : collectedRaw;
+      const complete = required > 0 ? collected >= required : collectedRaw > 0;
+      const ratio = required > 0 ? THREE.MathUtils.clamp(collected / Math.max(required, 1e-6), 0, 1) : 1;
+
+      const iconY = rowCenterY - Math.round(iconSize / 2);
+      this.drawResourceIcon(ctx, texture, resource.id, iconX, iconY, iconSize, complete ? '#12d06b' : baseColor);
+
+      const nameY = rowCenterY + nameBaselineOffset;
+      ctx.font = nameFont;
+      ctx.fillStyle = complete ? '#12d06b' : '#ffffff';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(truncate(displayName, nameMaxW, nameFont), nameX, nameY);
+
+      const barY = rowCenterY - Math.round(barHeight / 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.20)';
+      ctx.fillRect(barX - barOutline, barY - barOutline, barW + barOutline * 2, barHeight + barOutline * 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.12)';
+      ctx.fillRect(barX, barY, barW, barHeight);
+
+      let fillWidth = complete ? barW : Math.round(barW * ratio);
+      if (!complete && ratio > 0) {
+        fillWidth = Math.max(barMinFill, fillWidth);
+      }
+      if (complete || ratio > 0) {
+        ctx.fillStyle = complete ? '#12d06b' : '#ff4444';
+        ctx.fillRect(barX, barY, Math.min(barW, fillWidth), barHeight);
+      }
+
+      ctx.font = qtyFont;
+      ctx.fillStyle = '#e6e6e6';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(Math.round(required)), reqX, rowCenterY);
+    });
+
+    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.generateMipmaps = true;
+    texture.minFilter = THREE.LinearMipmapLinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.anisotropy = this.renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+    texture.needsUpdate = true;
+
+    this.cachedCanvasTexture?.dispose?.();
+    this.cachedCanvasTexture = texture;
+    this.lastAspect = widthRaw / Math.max(1, heightRaw);
+    this.lastContentHeightWorld = this.style.contentWorldHeight;
+    this.lastCropX = safeFraction;
+
+    return {
+      texture,
+      aspect: this.lastAspect,
+      contentHeightWorld: this.lastContentHeightWorld,
+      cropX: this.lastCropX,
+    };
+  }
+
+  dispose(): void {
+    this.cachedCanvasTexture?.dispose?.();
+    this.cachedCanvasTexture = null;
+  }
+
+  private computeDevicePixelRatio(): number {
+    const rendererRatio = this.renderer?.getPixelRatio?.();
+    const windowRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    return (rendererRatio ?? windowRatio ?? 1) * this.style.internalScale;
+  }
+
+  private normaliseResources(entries: HudResourceEntry[]): HudResourceEntry[] {
+    return entries
+      .map((entry) => ({
+        id: entry.id,
+        required: Math.max(0, Number(entry.required) || 0),
+        collected: Math.max(0, Number(entry.collected) || 0),
+      }))
+      .filter((entry) => entry.required > 0 || entry.collected > 0);
+  }
+
+  private drawResourceIcon(
+    ctx: CanvasRenderingContext2D,
+    texture: THREE.CanvasTexture,
+    resourceId: string,
+    x: number,
+    y: number,
+    size: number,
+    color: string
+  ): void {
+    const svgString = ResourceIcons.getIconForResource(resourceId, color);
+    const svgBlob = new Blob([svgString], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(svgBlob);
+    const img = new Image();
+
+    img.onload = () => {
+      ctx.drawImage(img, Math.round(x), Math.round(y), Math.round(size), Math.round(size));
+      texture.needsUpdate = true;
+      URL.revokeObjectURL(url);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+    };
+
+    img.src = url;
+  }
+}

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/HudRegistry.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+
+type HudSet = Set<THREE.Object3D>;
+
+type HudUserData = {
+  combinedHUD?: THREE.Object3D;
+  __hudOwnerId?: string;
+} & THREE.Object3D['userData'];
+
+export class HudRegistry {
+  private readonly scene: THREE.Scene;
+  private readonly registry = new Map<string, HudSet>();
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+  }
+
+  public register(ownerId: string, anchor: THREE.Object3D, hud: THREE.Object3D): void {
+    const set = this.ensureSet(ownerId);
+    set.add(hud);
+
+    if (hud.parent !== this.scene) {
+      this.scene.add(hud);
+    }
+
+    const data = this.ensureUserData(anchor) as HudUserData;
+    data.__hudOwnerId = ownerId;
+    data.combinedHUD = hud;
+  }
+
+  public detachFromAnchor(anchor: THREE.Object3D): void {
+    const data = anchor.userData as HudUserData | undefined;
+    if (!data) return;
+
+    const hud = data.combinedHUD;
+    if (!hud) return;
+
+    const ownerId = data.__hudOwnerId;
+    this.detach(ownerId, hud);
+
+    delete data.combinedHUD;
+    if (ownerId) delete data.__hudOwnerId;
+  }
+
+  public detachAll(ownerId: string): void {
+    const set = this.registry.get(ownerId);
+    if (!set) return;
+
+    for (const hud of Array.from(set)) {
+      this.disposeHud(hud);
+      set.delete(hud);
+    }
+
+    this.registry.delete(ownerId);
+  }
+
+  public detachFromObjectGraph(root: THREE.Object3D): void {
+    root.traverse((node) => {
+      this.detachFromAnchor(node);
+    });
+  }
+
+  public dispose(): void {
+    for (const ownerId of Array.from(this.registry.keys())) {
+      this.detachAll(ownerId);
+    }
+    this.registry.clear();
+  }
+
+  private detach(ownerId: string | undefined, hud: THREE.Object3D): void {
+    if (ownerId) {
+      const set = this.registry.get(ownerId);
+      if (set && set.delete(hud) && set.size === 0) {
+        this.registry.delete(ownerId);
+      }
+    } else {
+      this.detachBySearch(hud);
+    }
+
+    this.disposeHud(hud);
+  }
+
+  private detachBySearch(hud: THREE.Object3D): void {
+    for (const [id, set] of this.registry.entries()) {
+      if (set.delete(hud)) {
+        if (set.size === 0) {
+          this.registry.delete(id);
+        }
+        break;
+      }
+    }
+  }
+
+  private disposeHud(hud: THREE.Object3D): void {
+    this.scene.remove(hud);
+    hud.removeFromParent();
+
+    hud.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) {
+        const mesh = child as THREE.Mesh;
+        mesh.geometry?.dispose();
+        this.disposeMaterial(mesh.material);
+      }
+    });
+
+    hud.clear();
+  }
+
+  private disposeMaterial(material: THREE.Material | THREE.Material[] | undefined): void {
+    if (!material) return;
+
+    if (Array.isArray(material)) {
+      material.forEach((mat) => this.disposeMaterial(mat));
+      return;
+    }
+
+    const mat = material as THREE.Material & { map?: THREE.Texture };
+    if (mat.map) {
+      mat.map.dispose?.();
+    }
+
+    mat.dispose?.();
+  }
+
+  private ensureSet(ownerId: string): HudSet {
+    let set = this.registry.get(ownerId);
+    if (!set) {
+      set = new Set();
+      this.registry.set(ownerId, set);
+    }
+    return set;
+  }
+
+  private ensureUserData(anchor: THREE.Object3D): THREE.Object3D['userData'] {
+    if (!anchor.userData) {
+      anchor.userData = {};
+    }
+    return anchor.userData;
+  }
+}

--- a/src/ui/screens/colony/scene/Scene3D/renderers/hud/hudMath.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/hud/hudMath.ts
@@ -1,0 +1,54 @@
+import * as THREE from 'three';
+
+const _camPos = new THREE.Vector3();
+
+export function computeScreenSpaceScale(
+  camera: THREE.Camera,
+  worldPos: THREE.Vector3,
+  planeWorldHeight: number,
+  targetPx: number,
+  renderer: THREE.WebGLRenderer | undefined,
+  minScale: number,
+  maxScale: number
+): number {
+  const size = renderer?.getSize(new THREE.Vector2());
+  const dpr = renderer?.getPixelRatio?.() ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+  const viewportH = (size?.y ?? (typeof window !== 'undefined' ? window.innerHeight || 800 : 800)) * dpr;
+
+  if ((camera as any).isOrthographicCamera) {
+    const cam = camera as THREE.OrthographicCamera;
+    const orthoHeight = Math.max(1e-6, cam.top - cam.bottom);
+    const pxPerWorld = viewportH / orthoHeight;
+    const currentPx = planeWorldHeight * pxPerWorld;
+    const scale = Math.round(targetPx) / Math.max(1e-6, currentPx);
+    return THREE.MathUtils.clamp(scale, minScale, maxScale);
+  }
+
+  if ((camera as any).isPerspectiveCamera) {
+    (camera as THREE.Object3D).getWorldPosition(_camPos);
+    const distance = _camPos.distanceTo(worldPos);
+    const cam = camera as THREE.PerspectiveCamera;
+    const tan = Math.tan(THREE.MathUtils.degToRad(cam.fov) * 0.5);
+    const denom = Math.max(1e-6, 2 * distance * tan);
+    const heightToPixels = viewportH / denom;
+    const scale = Math.round(targetPx) / Math.max(1e-6, planeWorldHeight * heightToPixels);
+    return THREE.MathUtils.clamp(scale, minScale, maxScale);
+  }
+
+  return 1;
+}
+
+export function clampScaleByWidth(
+  baseScale: number,
+  aspect: number,
+  targetHeightPx: number,
+  maxWidthPx: number
+): number {
+  if (maxWidthPx <= 0) return baseScale;
+  const predictedWidthPx = targetHeightPx * aspect;
+  if (predictedWidthPx <= maxWidthPx) {
+    return baseScale;
+  }
+  const factor = maxWidthPx / Math.max(1e-6, predictedWidthPx);
+  return baseScale * factor;
+}


### PR DESCRIPTION
## Summary
- scale the building HUD canvas metrics, fonts, and resource bars by 50% to improve readability
- enlarge the road HUD layout to match, updating padding, fonts, and clamp limits for the new size
- ensure road HUDs appear as soon as a road is planned by using fallback segment counts, improved show/hide checks, and wiring the WebGL renderer/bridge through the manager

## Testing
- npm run build *(fails: repository already contains pre-existing TypeScript issues outside of these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6bddd5883208904aa039ea71b0a