### PR TITLE
Stop building collect loop when storage is full

### DIFF
--- a/src/logic/systems/commands/ParameterResolutionService.ts
+++ b/src/logic/systems/commands/ParameterResolutionService.ts
@@ -64,7 +64,7 @@ export class ParameterResolutionService {
         }
 
         const value = this.resolveParameter(param, resolveContext);
-        if (value !== null && value !== undefined) {
+        if (value !== undefined) {
           store.set(param.id, value, source);
           cachedValues = store.snapshot();
           resolvedParameters[param.id] = value;

--- a/src/logic/systems/commands/ParameterResolvers/ParameterResolverToolkit.ts
+++ b/src/logic/systems/commands/ParameterResolvers/ParameterResolverToolkit.ts
@@ -311,11 +311,40 @@ export class ParameterResolverToolkit {
     const closestStorageId = this.getClosestStorage(dronePos, 200);
     const storageAccess = closestStorageId ? this.getObjectAccessPoint(closestStorageId, objectId) : null;
 
+    const toFiniteNumber = (value: any): number | null => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+      }
+
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    const toPositiveNumber = (value: any): number => {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return 0;
+      }
+      return Math.max(0, numeric);
+    };
+
+    const normalizeResourceMap = (input: Record<string, number>): Record<string, number> => {
+      const normalized: Record<string, number> = {};
+      for (const [resourceId, rawValue] of Object.entries(input)) {
+        const positive = toPositiveNumber(rawValue);
+        if (positive > 0) {
+          normalized[resourceId] = positive;
+        }
+      }
+      return normalized;
+    };
+
     const inst = bm.getBuildingInstance?.(buildingId);
     const storageInfo = inst?.internalStorage?.[plan.resourceId];
     const drone = this.mapLogic?.scene?.getObjectById(objectId);
-    const droneStorageValues = Object.values(drone?.data?.storage || {}) as number[];
-    const droneLoad = droneStorageValues.reduce((sum, val) => sum + val, 0);
+    const droneStorageRecord = (drone?.data?.storage ?? {}) as Record<string, number>;
+    const droneStorageValues = Object.values(droneStorageRecord);
+    const droneLoad = droneStorageValues.reduce((sum, val) => sum + toPositiveNumber(val), 0);
     const droneMaxCapacity = drone?.data?.maxCapacity || 5;
     const droneFree = Math.max(0, droneMaxCapacity - droneLoad);
 
@@ -327,17 +356,8 @@ export class ParameterResolverToolkit {
       amount = Math.min(missing, droneFree || 5);
     }
 
+    const resourceManager: any = this.mapLogic?.resources;
     if (plan.direction === 'from-building') {
-      const toFiniteNumber = (value: any): number | null => {
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          return value;
-        }
-
-        const numeric = Number(value);
-        return Number.isFinite(numeric) ? numeric : null;
-      };
-
-      const resourceManager: any = this.mapLogic?.resources;
       const capacityValue = toFiniteNumber(resourceManager?.getResourceCapacity?.(plan.resourceId as any));
       const currentValue = toFiniteNumber(resourceManager?.getResourceAmount?.(plan.resourceId as any)) ?? 0;
 
@@ -347,31 +367,61 @@ export class ParameterResolverToolkit {
       }
     }
 
-    const loadResourcesMap: Record<string, number> = {};
-    loadResourcesMap[plan.resourceId] = Math.max(0, amount);
-
-    const droneStorage = Number(drone?.data?.storage?.[plan.resourceId]) || 0;
-    const unloadResourcesMap: Record<string, number> = {};
-
-    if (plan.direction === 'from-building') {
-      const expectedAfterLoad = Math.max(0, Math.min(droneMaxCapacity, droneStorage + Math.max(0, amount)));
-      unloadResourcesMap[plan.resourceId] = expectedAfterLoad;
-    } else {
-      unloadResourcesMap[plan.resourceId] = Math.max(0, droneStorage);
+    const positiveAmount = Math.max(0, amount);
+    const loadResourcesRaw: Record<string, number> = {};
+    if (positiveAmount > 0) {
+      loadResourcesRaw[plan.resourceId] = positiveAmount;
     }
 
-    if (loadResourcesMap[plan.resourceId] <= 0 && unloadResourcesMap[plan.resourceId] <= 0) {
-      return null;
+    const droneResourceAmount = toPositiveNumber(droneStorageRecord[plan.resourceId]);
+    const unloadResourcesRaw: Record<string, number> = {};
+
+    if (plan.direction === 'from-building') {
+      const expectedAfterLoad = Math.min(droneMaxCapacity, droneResourceAmount + positiveAmount);
+      if (expectedAfterLoad > 0) {
+        unloadResourcesRaw[plan.resourceId] = expectedAfterLoad;
+      }
+
+      for (const [resourceId, storedAmount] of Object.entries(droneStorageRecord)) {
+        const positiveStored = toPositiveNumber(storedAmount);
+        if (positiveStored <= 0) {
+          continue;
+        }
+
+        if (resourceId === plan.resourceId) {
+          unloadResourcesRaw[resourceId] = Math.max(unloadResourcesRaw[resourceId] ?? 0, positiveStored);
+        } else {
+          unloadResourcesRaw[resourceId] = positiveStored;
+        }
+      }
+    } else if (droneResourceAmount > 0) {
+      unloadResourcesRaw[plan.resourceId] = droneResourceAmount;
+    }
+
+    const loadResourcesMap = normalizeResourceMap(loadResourcesRaw);
+    const unloadResourcesMap = normalizeResourceMap(unloadResourcesRaw);
+
+    let hasStorageCapacity = true;
+    if (plan.direction === 'from-building' && Object.keys(unloadResourcesMap).length > 0) {
+      hasStorageCapacity = Object.keys(unloadResourcesMap).some(resourceId => {
+        const capacityValue = toFiniteNumber(resourceManager?.getResourceCapacity?.(resourceId as any));
+        if (capacityValue === null) {
+          return true;
+        }
+        const currentValue = toFiniteNumber(resourceManager?.getResourceAmount?.(resourceId as any)) ?? 0;
+        return capacityValue - Math.max(0, currentValue) > 0;
+      });
     }
 
     return {
       ...plan,
-      amount: Math.max(0, amount),
+      amount: positiveAmount,
       buildingAccessPoint: buildingAccess,
       closestStorageId,
       storageAccessPoint: storageAccess,
       resources: loadResourcesMap,
-      resourcesToUnload: unloadResourcesMap
+      resourcesToUnload: unloadResourcesMap,
+      hasStorageCapacity
     };
   }
 

--- a/src/logic/systems/commands/db/command-groups-db.ts
+++ b/src/logic/systems/commands/db/command-groups-db.ts
@@ -1,6 +1,6 @@
 import { CommandGroup } from '../command-group.types';
 import { CommandFailureCode } from '../command.types';
-import { sequence, loop, action } from '../plans/PlanBuilder';
+import { sequence, loop, action, condition } from '../plans/PlanBuilder';
 import { buildCommand } from '../plans/PlanCommandFactory';
 
 // База даних груп команд
@@ -362,25 +362,42 @@ export const COMMAND_GROUPS: CommandGroup[] = [
       { id: 'validatePositions1', getterType: 'validate', args: [ { type:'lit', value:'objectExists' }, { type:'var', value:'resolved.storagePosition' } ], resolveWhen: 'before-command' },
       { id: 'validatePositions2', getterType: 'validate', args: [ { type:'lit', value:'objectExists' }, { type:'var', value:'resolved.buildingPosition' } ], resolveWhen: 'before-command' },
       { id: 'planResourcesToUnload', getterType: 'literal', args: [ { type:'var', value:'resolved.plan.resourcesToUnload' } ], resolveWhen: 'before-command' },
+      { id: 'planHasStorageCapacity', getterType: 'literal', args: [ { type:'var', value:'resolved.plan.hasStorageCapacity' } ], resolveWhen: 'before-command' },
     ],
     plan: loop('building-collect-plan', ctx => {
       const validation = ctx.getResolvedValue<{ success: boolean }>('validateAmount');
+      const resourcesToUnload = ctx.getResolvedValue<Record<string, number> | undefined>('planResourcesToUnload') || {};
+      const hasResourcesToUnload = Object.values(resourcesToUnload).some(value => Number(value) > 0);
+      const hasStorageCapacity = ctx.getResolvedValue<boolean>('planHasStorageCapacity');
+
+      if (hasResourcesToUnload) {
+        if (hasStorageCapacity === false) {
+          return false;
+        }
+        return true;
+      }
+
       return !validation || validation.success;
     }, [
-      action('move-to-building', ctx =>
-        buildCommand(ctx, 'move-to', {
-          priority: 1,
-          parameters: { priority: 'high' },
-          resolvedParamsMapping: { position: 'buildingPosition' }
-        })
-      ),
-      action('load-from-building', ctx =>
-        buildCommand(ctx, 'load-resources', {
-          priority: 2,
-          parameters: { resources: ctx.context.resolved?.plan?.resources || {} },
-          resolvedParamsMapping: { targetId: 'buildingId' }
-        })
-      ),
+      condition('building-collect-should-load', ctx => {
+        const amount = ctx.getResolvedValue<number>('planAmount');
+        return typeof amount === 'number' && amount > 0;
+      }, [
+        action('move-to-building', ctx =>
+          buildCommand(ctx, 'move-to', {
+            priority: 1,
+            parameters: { priority: 'high' },
+            resolvedParamsMapping: { position: 'buildingPosition' }
+          })
+        ),
+        action('load-from-building', ctx =>
+          buildCommand(ctx, 'load-resources', {
+            priority: 2,
+            parameters: { resources: ctx.context.resolved?.plan?.resources || {} },
+            resolvedParamsMapping: { targetId: 'buildingId' }
+          })
+        )
+      ]),
       action('move-to-storage', ctx =>
         buildCommand(ctx, 'move-to', {
           priority: 3,


### PR DESCRIPTION
## Summary
- allow parameter resolvers to clear cached values when they resolve to null
- extend building transfer planning to unload extra cargo and detect storage capacity limits
- update the building collect loop to skip useless trips and stop when global storage is full

## Testing
- npm run test:commands

------
https://chatgpt.com/codex/tasks/task_e_68d165a251188320b4431683a941e2d0