### PR TITLE
Dispose explosion and rock renderer resources

### DIFF
--- a/src/ui/screens/colony/scene/CameraController/CameraController.ts
+++ b/src/ui/screens/colony/scene/CameraController/CameraController.ts
@@ -78,7 +78,7 @@ export class CameraController {
     this.domElement.addEventListener('mousemove', this.handleMouseMove)
     this.domElement.addEventListener('mouseup', this.handleMouseUp)
     this.domElement.addEventListener('wheel', this.handleWheel)
-    this.domElement.addEventListener('contextmenu', (e) => e.preventDefault())
+    this.domElement.addEventListener('contextmenu', this.handleContextMenu)
   }
 
   // Public methods for setting callbacks
@@ -209,7 +209,7 @@ export class CameraController {
   private handleWheel = (event: WheelEvent) => {
     event.preventDefault()
     const delta = event.deltaY > 0 ? -1 : 1
-    
+
     if (this.isPinned) {
       // При пінінгу - зум навколо закріпленого об'єкта
       this.updatePinnedZoom(delta)
@@ -217,6 +217,10 @@ export class CameraController {
       // Звичайний зум
       this.zoomCamera(delta)
     }
+  }
+
+  private handleContextMenu = (event: MouseEvent) => {
+    event.preventDefault()
   }
 
   // Camera movement methods
@@ -503,5 +507,6 @@ export class CameraController {
     this.domElement.removeEventListener('mousemove', this.handleMouseMove)
     this.domElement.removeEventListener('mouseup', this.handleMouseUp)
     this.domElement.removeEventListener('wheel', this.handleWheel)
+    this.domElement.removeEventListener('contextmenu', this.handleContextMenu)
   }
 }

--- a/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
+++ b/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
@@ -155,11 +155,15 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
 
     window.addEventListener('wheel', onWheel, { passive: false });
     window.addEventListener('resize', onResize);
-    renderer.domElement.addEventListener('contextmenu', (e) => e.preventDefault());
+    const preventContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+    renderer.domElement.addEventListener('contextmenu', preventContextMenu);
 
     return () => {
       window.removeEventListener('wheel', onWheel);
       window.removeEventListener('resize', onResize);
+      renderer.domElement.removeEventListener('contextmenu', preventContextMenu);
       if (mountRef.current?.contains(renderer.domElement)) {
         mountRef.current.removeChild(renderer.domElement);
       }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/CloudRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/CloudRenderer.ts
@@ -154,11 +154,34 @@ export class CloudRenderer extends BaseRenderer {
     if (cloud) {
       this.cloudGroup.remove(cloud);
       if (cloud instanceof THREE.Points) {
+        const index = this.dustParticles.indexOf(cloud);
+        if (index !== -1) {
+          this.dustParticles.splice(index, 1);
+        }
         cloud.geometry.dispose();
         // матеріал — спільний, не диспоузимо!
       }
     }
     super.remove(id);
+  }
+
+  dispose(): void {
+    for (const cloud of this.dustParticles) {
+      this.cloudGroup.remove(cloud);
+      if (cloud instanceof THREE.Points) {
+        cloud.geometry.dispose();
+      }
+    }
+    this.dustParticles.length = 0;
+
+    this.scene.remove(this.cloudGroup);
+
+    if (CloudRenderer.sharedMaterial) {
+      CloudRenderer.sharedMaterial.dispose();
+      CloudRenderer.sharedMaterial = null;
+    }
+
+    super.dispose();
   }
 
   // Викликати раз за кадр

--- a/src/ui/screens/colony/scene/Scene3D/renderers/ExplosionRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/ExplosionRenderer.ts
@@ -641,6 +641,14 @@ void main(){
 
   // ==== API ====
   render(object: TSceneObject): THREE.Object3D {
+    if (!this.group.parent) {
+      this.scene.add(this.group);
+    }
+
+    if (this.points.parent !== this.group) {
+      this.group.add(this.points);
+    }
+
     const idx = this.addExplosion(object.coordinates, {
       particleSize:    object.data?.particleSize ?? 26.0,
       particleSizeEnd: object.data?.particleSizeEnd ?? 10.0,
@@ -666,7 +674,7 @@ void main(){
       flashSizePx:     object.data?.flashSizePx,
     });
 
-    this.addMesh(object.id, this.points);
+    this.meshes.set(object.id, this.points);
     (this.points as any).__explosionIndexMap.set(object.id, idx);
     return this.points;
   }
@@ -684,6 +692,112 @@ void main(){
       this.killExplosion(idx);
       map.delete(id);
     }
+
+    this.meshes.delete(id);
+
+    if (this.meshes.size > 0) return;
+
+    map?.clear();
+
+    this.hudRegistry.detachFromObjectGraph(this.points);
+
+    if (this.points.parent === this.group) {
+      this.group.remove(this.points);
+    }
+
+    if (this.points.parent === this.scene) {
+      this.scene.remove(this.points);
+    }
+
+    for (let i = 0; i < this.flashMeshes.length; i += 1) {
+      const mesh = this.flashMeshes[i];
+      if (!mesh) continue;
+
+      this.group.remove(mesh);
+      (mesh.material as THREE.Material).dispose();
+      (mesh.geometry as THREE.BufferGeometry).dispose();
+      this.flashMeshes[i] = null;
+    }
+
+    this.flashMeshes = [];
+
+    if (this.group.parent === this.scene) {
+      this.scene.remove(this.group);
+    }
+  }
+
+  dispose(): void {
+    const map: Map<string, number> | undefined = (this.points as any).__explosionIndexMap;
+    map?.clear();
+
+    this.hudRegistry.detachFromObjectGraph(this.points);
+
+    if (this.points.parent === this.group) {
+      this.group.remove(this.points);
+    }
+
+    if (this.points.parent === this.scene) {
+      this.scene.remove(this.points);
+    }
+
+    if (this.group.parent === this.scene) {
+      this.scene.remove(this.group);
+    }
+
+    (this.material as THREE.ShaderMaterial | undefined)?.dispose();
+    (this.geometry as THREE.BufferGeometry | undefined)?.dispose();
+    this.particleTex.dispose?.();
+
+    for (let i = 0; i < this.flashMeshes.length; i += 1) {
+      const mesh = this.flashMeshes[i];
+      if (!mesh) continue;
+
+      this.group.remove(mesh);
+      (mesh.material as THREE.Material).dispose();
+      (mesh.geometry as THREE.BufferGeometry).dispose();
+      this.flashMeshes[i] = null;
+    }
+
+    this.flashMeshes = [];
+
+    this.flashLifeArr = [];
+    this.flashRadiusArr = [];
+    this.flashAlphaArr = [];
+    this.flashStart = [];
+    this.flashColorArr = [];
+    this.flashSoftnessArr = [];
+    this.flashFadeExpArr = [];
+    this.flashIntensityArr = [];
+
+    this.emitTex1.dispose();
+    this.emitTex2.dispose();
+    this.emitTex3.dispose();
+    this.emitTex4.dispose();
+    this.emitTex5.dispose();
+
+    this.spawnMapTex.dispose();
+    this.aliveTex.dispose();
+
+    this.texPos?.dispose?.();
+    this.texAux?.dispose?.();
+
+    this.gpu?.dispose?.();
+
+    this.emit1Data = new Float32Array(0);
+    this.emit2Data = new Float32Array(0);
+    this.emit3Data = new Float32Array(0);
+    this.emit4Data = new Float32Array(0);
+    this.emit5Data = new Float32Array(0);
+    this.spawnMapData = new Float32Array(0);
+    this.aliveData = new Float32Array(0);
+    this.remainingToSpawn = new Int32Array(0);
+    this.ttlSeconds = [];
+    this.startTime = [];
+    this.explosionActive = [];
+
+    this.meshes.clear();
+
+    super.dispose();
   }
 
   private addExplosion(position: Vec3, opts: ExplosionData = {}): number {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/FireRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/FireRenderer.ts
@@ -667,6 +667,43 @@ export class FireRenderer extends BaseRenderer {
     }
   }
 
+  dispose(): void {
+    const map: Map<string, number> | undefined = (this.points as any)?.__emitterIndexMap;
+    map?.clear();
+
+    this.points?.removeFromParent();
+    this.group.removeFromParent();
+    this.group.clear();
+
+    this.material?.dispose();
+    this.geometry?.dispose();
+
+    this.spawnMapTex.dispose();
+    this.emitPosTex.dispose();
+    this.emitColTex.dispose();
+    this.emitPropTex.dispose();
+    this.emitExtraTex.dispose();
+
+    if (this.gpu) {
+      this.gpu.dispose();
+    }
+
+    this.emitPosData = new Float32Array(0);
+    this.emitColData = new Float32Array(0);
+    this.emitPropData = new Float32Array(0);
+    this.emitExtraData = new Float32Array(0);
+    this.spawnMapData8 = new Uint8Array(0);
+    this.emitAcc = new Float32Array(0);
+
+    this.emitterActive = [];
+    this.touched = [];
+    this.primeQueue = [];
+    this.emitterCount = 0;
+    this.spawnHead = 0;
+
+    super.dispose();
+  }
+
   // «ручки»
   setSpeed(speed: number)      { (this.posVar.material.uniforms.uSpeed     as any).value = speed; }
   setBasePointSize(px: number) { (this.material.uniforms.uPointSize        as any).value = px; }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RockRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RockRenderer.ts
@@ -436,6 +436,72 @@ export class RockRenderer extends BaseRenderer {
     }
   }
 
+  dispose(): void {
+    const disposedGeometries = new Set<THREE.BufferGeometry>();
+    const disposedMaterials = new Set<THREE.Material>();
+
+    const disposeGeometry = (geometry?: THREE.BufferGeometry | null) => {
+      if (!geometry || disposedGeometries.has(geometry)) return;
+      disposedGeometries.add(geometry);
+      geometry.dispose();
+    };
+
+    for (const [bucketKey, mesh] of this.meshBuckets) {
+      this.hudRegistry.detachFromObjectGraph(mesh);
+      mesh.removeFromParent();
+
+      disposeGeometry(mesh.geometry as THREE.BufferGeometry);
+      this.disposeMaterial(mesh.material, disposedMaterials);
+
+      if (!this.isDefaultBucket(bucketKey)) {
+        this.materialCacheByColor.delete(bucketKey);
+      }
+    }
+
+    this.meshBuckets.clear();
+    this.nextInstanceId.clear();
+    this.freeInstanceIds.clear();
+    this.highestActiveIndex.clear();
+
+    for (const { mesh } of this.pendingFallbacks.values()) {
+      this.hudRegistry.detachFromObjectGraph(mesh);
+      mesh.removeFromParent();
+      disposeGeometry(mesh.geometry as THREE.BufferGeometry);
+      this.disposeMaterial(mesh.material, disposedMaterials);
+    }
+    this.pendingFallbacks.clear();
+
+    this.instances.clear();
+
+    for (const geometry of this.geometryCache.values()) {
+      disposeGeometry(geometry);
+    }
+    this.geometryCache.clear();
+
+    for (const material of this.materialCacheByColor.values()) {
+      this.disposeMaterial(material, disposedMaterials);
+    }
+    this.materialCacheByColor.clear();
+
+    for (const group of this.modelCache.values()) {
+      group.traverse((child) => {
+        const maybeMesh = child as THREE.Mesh;
+        if (!(maybeMesh as any).isMesh) return;
+
+        disposeGeometry(maybeMesh.geometry as THREE.BufferGeometry);
+        this.disposeMaterial(maybeMesh.material as THREE.Material | THREE.Material[], disposedMaterials);
+      });
+      group.clear();
+    }
+    this.modelCache.clear();
+
+    this.modelsReady = false;
+
+    this.meshes.clear();
+
+    super.dispose();
+  }
+
   cleanupInactiveInstances(): void {
     // Проходимо лише по реально вільних слотах (якщо хочеш періодично "обнуляти" матриці)
     this.freeInstanceIds.forEach((ids, bucketKey) => {
@@ -466,5 +532,40 @@ export class RockRenderer extends BaseRenderer {
 
   private hex6(n: number): string {
     return (n >>> 0).toString(16).padStart(6, '0').toUpperCase();
+  }
+
+  private disposeMaterial(
+    material: THREE.Material | THREE.Material[] | undefined,
+    disposed: Set<THREE.Material>,
+  ): void {
+    if (!material) return;
+
+    if (Array.isArray(material)) {
+      material.forEach((mat) => this.disposeMaterial(mat, disposed));
+      return;
+    }
+
+    if (disposed.has(material)) return;
+    disposed.add(material);
+
+    const textureProps = [
+      'map',
+      'lightMap',
+      'aoMap',
+      'emissiveMap',
+      'bumpMap',
+      'normalMap',
+      'displacementMap',
+      'roughnessMap',
+      'metalnessMap',
+      'alphaMap',
+    ] as const;
+
+    for (const key of textureProps) {
+      const tex = (material as any)[key] as THREE.Texture | undefined;
+      tex?.dispose?.();
+    }
+
+    material.dispose();
   }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/SmokeRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/SmokeRenderer.ts
@@ -665,6 +665,42 @@ export class SmokeRenderer extends BaseRenderer {
     }
   }
 
+  dispose(): void {
+    const map: Map<string, number> | undefined = (this.points as any)?.__emitterIndexMap;
+    map?.clear();
+
+    this.points?.removeFromParent();
+    this.group.removeFromParent();
+    this.group.clear();
+
+    this.material?.dispose();
+    this.geometry?.dispose();
+
+    this.spawnMapTex.dispose();
+    this.emitPosTex.dispose();
+    this.emitColTex.dispose();
+    this.emitPropTex.dispose();
+    this.emitExtraTex.dispose();
+
+    if (this.gpu) {
+      this.gpu.dispose();
+    }
+
+    this.emitPosData = new Float32Array(0);
+    this.emitColData = new Float32Array(0);
+    this.emitPropData = new Float32Array(0);
+    this.emitExtraData = new Float32Array(0);
+    this.spawnMapData8 = new Uint8Array(0);
+    this.emitAcc = new Float32Array(0);
+
+    this.emitterActive = [];
+    this.touched = [];
+    this.emitterCount = 0;
+    this.spawnHead = 0;
+
+    super.dispose();
+  }
+
   // «ручки»
   setSpeed(speed: number)          { (this.posVar.material.uniforms.uSpeed as any).value = speed; }
   setBasePointSize(px: number)     { (this.material.uniforms.uPointSize    as any).value = px; }

--- a/src/ui/screens/colony/scene/hooks/useCameraSystems.ts
+++ b/src/ui/screens/colony/scene/hooks/useCameraSystems.ts
@@ -21,6 +21,12 @@ export function useCameraController(
   }, [camera, renderer]);
 
   useEffect(() => {
+    return () => {
+      controller.dispose();
+    };
+  }, [controller]);
+
+  useEffect(() => {
     controller.setGetTerrainHeight((x, z) => {
       const tm = mapLogicRef.current?.scene.getTerrainManager();
       return tm ? tm.getHeightAt(x, z) : undefined;

--- a/src/ui/screens/colony/scene/interaction/InteractionManager.ts
+++ b/src/ui/screens/colony/scene/interaction/InteractionManager.ts
@@ -21,13 +21,13 @@ export class InteractionManager {
 
   private setupEventListeners(): void {
     // Один раз на весь додаток - всі обробники подій миші тут
-    document.addEventListener('mousedown', this.handleMouseDown.bind(this));
-    document.addEventListener('mousemove', this.handleMouseMove.bind(this));
-    document.addEventListener('mouseup', this.handleMouseUp.bind(this));
-    document.addEventListener('contextmenu', this.handleContextMenu.bind(this));
+    document.addEventListener('mousedown', this.handleMouseDown);
+    document.addEventListener('mousemove', this.handleMouseMove);
+    document.addEventListener('mouseup', this.handleMouseUp);
+    document.addEventListener('contextmenu', this.handleContextMenu);
   }
 
-  private handleMouseDown(event: MouseEvent): void {
+  private readonly handleMouseDown = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
     if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
@@ -36,7 +36,7 @@ export class InteractionManager {
 
     this.isMouseDown = true;
     this.mousePosition = { x: event.clientX, y: event.clientY };
-    
+
     // Делегуємо до активного хендлера
     const activeHandler = this.handlers.get(this.currentMode);
     if (activeHandler) {
@@ -45,9 +45,9 @@ export class InteractionManager {
 
     // Емітимо подію для інших підписників
     this.emit('mousedown', { event, mode: this.currentMode });
-  }
+  };
 
-  private handleMouseMove(event: MouseEvent): void {
+  private readonly handleMouseMove = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
     if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
@@ -63,9 +63,9 @@ export class InteractionManager {
 
     // Емітимо подію для інших підписників
     this.emit('mousemove', { event, mode: this.currentMode });
-  }
+  };
 
-  private handleMouseUp(event: MouseEvent): void {
+  private readonly handleMouseUp = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
     if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
@@ -73,7 +73,7 @@ export class InteractionManager {
     }
 
     this.isMouseDown = false;
-    
+
     // Делегуємо до активного хендлера
     const activeHandler = this.handlers.get(this.currentMode);
     if (activeHandler) {
@@ -82,20 +82,20 @@ export class InteractionManager {
 
     // Емітимо подію для інших підписників
     this.emit('mouseup', { event, mode: this.currentMode });
-  }
+  };
 
-  private handleContextMenu(event: MouseEvent): void {
+  private readonly handleContextMenu = (event: MouseEvent): void => {
     event.preventDefault();
-    
+
     // Делегуємо до активного хендлера
     const activeHandler = this.handlers.get(this.currentMode);
     if (activeHandler) {
       activeHandler.onContextMenu(event);
     }
-    
+
     // Логіка для правої кнопки миші
     this.emit('contextmenu', { event, mode: this.currentMode });
-  }
+  };
 
   registerHandler(mode: InteractionMode, handler: InteractionHandler): void {
     this.handlers.set(mode, handler);
@@ -210,10 +210,10 @@ export class InteractionManager {
 
   dispose(): void {
     // Видаляємо всі обробники подій
-    document.removeEventListener('mousedown', this.handleMouseDown.bind(this));
-    document.removeEventListener('mousemove', this.handleMouseMove.bind(this));
-    document.removeEventListener('mouseup', this.handleMouseUp.bind(this));
-    document.removeEventListener('contextmenu', this.handleContextMenu.bind(this));
+    document.removeEventListener('mousedown', this.handleMouseDown);
+    document.removeEventListener('mousemove', this.handleMouseMove);
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.removeEventListener('contextmenu', this.handleContextMenu);
 
     // Очищаємо хендлери
     this.handlers.forEach(handler => handler.dispose());


### PR DESCRIPTION
## Summary
- ensure ExplosionRenderer detaches its shared points when the last explosion is removed and frees all compute textures during dispose
- add a RockRenderer teardown path that removes instancing buckets, disposes cached meshes/materials, and clears renderer bookkeeping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17857caa88320b8e1c9e59b2ecf91