### PR TITLE
Add scene preloader and enable terrain shadows

### DIFF
--- a/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
+++ b/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { ISaveManager, IMapLogic } from '@interfaces/index';
 import { CommandPanel, SegmentedConstructionPanel } from '@ui/screens/colony';
@@ -19,6 +19,8 @@ import { useSelectedUnits, useSelectionHighlights } from '../hooks/useSelectionS
 import { useCommandBridge } from '../hooks/useCommandBridge';
 import { useSceneObjectSync } from '../hooks/useSceneSync';
 import { useRenderLoop } from '../hooks/useRenderLoop';
+import { SceneLoadingManager, useSceneLoadingSnapshot } from './loading/SceneLoadingManager';
+import { SceneLoadingOverlay } from '../components/SceneLoadingOverlay';
 
 interface Scene3DProps {
   saveManager: ISaveManager;
@@ -31,6 +33,19 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
   const mountRef = useRef<HTMLDivElement>(null);
 
   const { scene, camera, renderer } = useSceneCore();
+  const loadingManagerRef = useRef<SceneLoadingManager | null>(null);
+  if (!loadingManagerRef.current) {
+    loadingManagerRef.current = new SceneLoadingManager();
+  }
+  const loadingManager = loadingManagerRef.current;
+  const loadingSnapshot = useSceneLoadingSnapshot(loadingManager);
+  const [isSceneReady, setIsSceneReady] = useState(false);
+  const manualPending = Math.max(0, loadingSnapshot.manualTotal - loadingSnapshot.manualCompleted);
+  const loadingMessage = loadingSnapshot.lastUrl
+    ? `Завантаження: ${loadingSnapshot.lastUrl.split('/').pop()}`
+    : manualPending > 0
+      ? 'Генерація світу...'
+      : undefined;
 
   const {
     rendererManagerRef,
@@ -39,9 +54,13 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
     areaSelectionRendererRef,
     mapLogicRef,
     managersReady,
-  } = useSceneManagers(scene, camera, renderer, appMapLogic);
+  } = useSceneManagers(scene, camera, renderer, appMapLogic, loadingManager);
 
-  const { buildingPreviewRef, isReady: buildingPreviewReady } = useBuildingPreview(scene, appMapLogic);
+  const { buildingPreviewRef, isReady: buildingPreviewReady } = useBuildingPreview(
+    scene,
+    appMapLogic,
+    loadingManager.getLoadingManager(),
+  );
   const controller = useCameraController(camera, renderer, mapLogicRef);
   const debugInfo = useDebugInfo(camera, controller, mapLogicRef, buildingPreviewRef);
 
@@ -93,6 +112,12 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
     areaSelectionRendererRef,
     mapLogicRef,
   );
+
+  useEffect(() => {
+    if (!isSceneReady && managersReady && buildingPreviewReady && loadingManager.isDone()) {
+      setIsSceneReady(true);
+    }
+  }, [isSceneReady, managersReady, buildingPreviewReady, loadingManager, loadingSnapshot]);
 
   useEffect(() => {
     const map = mapLogicRef.current;
@@ -172,6 +197,13 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
 
   return (
     <div ref={mountRef} style={{ width: '100%', height: '100vh', position: 'relative', overflow: 'hidden' }}>
+      {!isSceneReady && (
+        <SceneLoadingOverlay
+          progress={loadingManager.getProgress()}
+          message={loadingMessage}
+          errors={loadingSnapshot.errors.length ? loadingSnapshot.errors : undefined}
+        />
+      )}
       {interactionManager && (
         <InteractionProvider value={interactionManager}>
           <VerticalMenuWithContext game={game} onShowMainMenu={onShowMainMenu} />

--- a/src/ui/screens/colony/scene/Scene3D/loading/SceneLoadingManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/loading/SceneLoadingManager.ts
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import * as THREE from 'three';
+
+export interface SceneLoadingSnapshot {
+  itemsLoaded: number;
+  itemsTotal: number;
+  manualCompleted: number;
+  manualTotal: number;
+  errors: string[];
+  lastUrl?: string;
+}
+
+type Listener = (snapshot: SceneLoadingSnapshot) => void;
+
+export class SceneLoadingManager {
+  private readonly loadingManager: THREE.LoadingManager;
+  private snapshot: SceneLoadingSnapshot = {
+    itemsLoaded: 0,
+    itemsTotal: 0,
+    manualCompleted: 0,
+    manualTotal: 0,
+    errors: [],
+    lastUrl: undefined,
+  };
+
+  private readonly listeners = new Set<Listener>();
+
+  constructor() {
+    this.loadingManager = new THREE.LoadingManager();
+
+    this.loadingManager.onStart = (url, itemsLoaded, itemsTotal) => {
+      this.updateProgress(url, itemsLoaded, itemsTotal);
+    };
+
+    this.loadingManager.onProgress = (url, itemsLoaded, itemsTotal) => {
+      this.updateProgress(url, itemsLoaded, itemsTotal);
+    };
+
+    this.loadingManager.onLoad = () => {
+      this.updateProgress(undefined, this.snapshot.itemsTotal, this.snapshot.itemsTotal);
+    };
+
+    this.loadingManager.onError = (url) => {
+      this.snapshot = {
+        ...this.snapshot,
+        errors: url ? [...this.snapshot.errors, url] : this.snapshot.errors,
+        lastUrl: url ?? this.snapshot.lastUrl,
+        itemsLoaded: Math.min(this.snapshot.itemsTotal, this.snapshot.itemsLoaded + 1),
+      };
+      this.emit();
+    };
+  }
+
+  public getLoadingManager(): THREE.LoadingManager {
+    return this.loadingManager;
+  }
+
+  public getSnapshot(): SceneLoadingSnapshot {
+    return this.snapshot;
+  }
+
+  public subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public trackPromise<T>(promise: Promise<T>): Promise<T> {
+    this.snapshot = {
+      ...this.snapshot,
+      manualTotal: this.snapshot.manualTotal + 1,
+    };
+    this.emit();
+
+    return promise.finally(() => {
+      this.snapshot = {
+        ...this.snapshot,
+        manualCompleted: Math.min(
+          this.snapshot.manualTotal,
+          this.snapshot.manualCompleted + 1,
+        ),
+      };
+      this.emit();
+    });
+  }
+
+  public getProgress(): number {
+    const total = this.snapshot.itemsTotal + this.snapshot.manualTotal;
+    if (total === 0) {
+      return 1;
+    }
+    const loaded = this.snapshot.itemsLoaded + this.snapshot.manualCompleted;
+    return Math.min(1, loaded / total);
+  }
+
+  public isDone(): boolean {
+    return (
+      this.snapshot.itemsLoaded >= this.snapshot.itemsTotal &&
+      this.snapshot.manualCompleted >= this.snapshot.manualTotal
+    );
+  }
+
+  private updateProgress(url: string | undefined, itemsLoaded: number, itemsTotal: number): void {
+    this.snapshot = {
+      ...this.snapshot,
+      itemsLoaded,
+      itemsTotal,
+      lastUrl: url ?? this.snapshot.lastUrl,
+    };
+    this.emit();
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}
+
+export function useSceneLoadingSnapshot(manager: SceneLoadingManager) {
+  const [snapshot, setSnapshot] = React.useState<SceneLoadingSnapshot>(manager.getSnapshot());
+
+  React.useEffect(() => manager.subscribe(setSnapshot), [manager]);
+
+  return snapshot;
+}

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -40,7 +40,7 @@ export class BuildingRenderer extends BaseRenderer {
   
   private uiLogicBridge: UiLogicBridge | null = null; // Bridge to logic for storage info
 
-  constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer) {
+  constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer, loadingManager?: THREE.LoadingManager) {
     super(scene, renderer);
 
     this.geometry = new THREE.BoxGeometry(1, 1, 1);
@@ -54,7 +54,7 @@ export class BuildingRenderer extends BaseRenderer {
       fog: false,
     });
 
-    this.loader = new GLTFLoader();
+    this.loader = new GLTFLoader(loadingManager ?? undefined);
     this.hudBuilder = new HudCanvasBuilder(renderer, this.hudStyle);
   }
 
@@ -181,6 +181,9 @@ export class BuildingRenderer extends BaseRenderer {
           } else if (child.material?.clone) {
             child.material = child.material.clone();
           }
+
+          child.castShadow = true;
+          child.receiveShadow = true;
         }
       });
 
@@ -538,6 +541,8 @@ export class BuildingRenderer extends BaseRenderer {
     const material = this.material.clone();
     const mesh = new THREE.Mesh(this.geometry, material);
     mesh.position.set(0, 0, 0);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
     return mesh;
   }
 

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -23,12 +23,15 @@ export class RendererManager {
     private renderer: THREE.WebGLRenderer;
     private bridge: UiLogicBridge | null = null;
 
-    constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer, bridge?: UiLogicBridge) {
+    constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer, bridge?: UiLogicBridge, loadingManager?: THREE.LoadingManager) {
         this.scene = scene;
         this.renderer = renderer;
         if (bridge) this.bridge = bridge;
+        this.loadingManager = loadingManager || null;
         this.initializeRenderers();
     }
+
+    private loadingManager: THREE.LoadingManager | null = null;
 
     public setBridge(bridge: UiLogicBridge): void {
         this.bridge = bridge;
@@ -53,7 +56,7 @@ export class RendererManager {
         })); // Каменюки типу rock з звичайним рендерингом
         this.registerRenderer('biomass', new BiomassRenderer(this.scene)); // Біомаса
         this.registerRenderer('rover', new RoverRenderer(this.scene)); // Rover об'єкти
-        const buildingRenderer = new BuildingRenderer(this.scene, this.renderer);
+        const buildingRenderer = new BuildingRenderer(this.scene, this.renderer, this.loadingManager || undefined);
         if (this.bridge && (buildingRenderer as any).setUiLogicBridge) {
             (buildingRenderer as any).setUiLogicBridge(this.bridge);
         }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
@@ -10,7 +10,7 @@ export class TerrainRenderer {
   private textureManager: TextureManager;
 
   private geometry: THREE.PlaneGeometry | null = null;
-  private material: THREE.ShaderMaterial | null = null;
+  private material: THREE.Material | null = null;
 
   private lastRenderPosition: { x: number, z: number } | null = null;
   private rerenderThreshold = 50;
@@ -25,10 +25,10 @@ export class TerrainRenderer {
   // Кеш списку текстур для блендів (щоб не перевизначати атрибути щоразу)
   private cachedTextureNames: string[] = [];
 
-  constructor(scene: THREE.Scene, terrainManager: TerrainManager) {
+  constructor(scene: THREE.Scene, terrainManager: TerrainManager, loadingManager?: THREE.LoadingManager) {
     this.scene = scene;
     this.terrainManager = terrainManager;
-    this.textureManager = new TextureManager();
+    this.textureManager = new TextureManager(loadingManager);
   }
 
   /**
@@ -69,7 +69,7 @@ export class TerrainRenderer {
       this.terrainMesh = new THREE.Mesh(this.geometry, this.material);
       this.terrainMesh.matrixAutoUpdate = true;
       this.terrainMesh.castShadow = false;
-      this.terrainMesh.receiveShadow = false;
+      this.terrainMesh.receiveShadow = true;
       this.terrainMesh.frustumCulled = true;
 
       this.scene.add(this.terrainMesh);
@@ -238,109 +238,84 @@ export class TerrainRenderer {
   /**
    * Створює матеріал з world-locked UV: семпл за світовими XZ, wrap = Repeat.
    */
-  private createMultiTextureMaterial(): THREE.ShaderMaterial {
-    const textureNames = Object.keys(MAP_CONFIG.terrain.textures || {});
-    const uniforms: { [key: string]: any } = {};
+  private createMultiTextureMaterial(): THREE.MeshLambertMaterial {
+    const texturesConfig = (MAP_CONFIG.terrain.textures ?? {}) as Record<string, {
+      tiling?: { x: number; y: number };
+    }>;
+    const textureNames = Object.keys(texturesConfig);
 
-    // Текстури + тайлінги (wrap → Repeat)
-    for (const name of textureNames) {
-      const tex = this.textureManager.getTexture(name);
-      if (tex) {
-        tex.wrapS = THREE.RepeatWrapping;
-        tex.wrapT = THREE.RepeatWrapping;
-        tex.needsUpdate = true;
-        uniforms[`texture_${name}`] = { value: tex };
-      }
-      const tiling = (MAP_CONFIG.terrain.textures as any)[name]?.tiling;
-      if (tiling) {
-        // Інтерпретується як «повторів на 1 світову одиницю»
-        uniforms[`tiling_${name}`] = { value: new THREE.Vector2(tiling.x, tiling.y) };
-      } else {
-        uniforms[`tiling_${name}`] = { value: new THREE.Vector2(1, 1) };
-      }
-    }
-
-    return new THREE.ShaderMaterial({
-      uniforms,
-      vertexShader: this.createVertexShader(textureNames),
-      fragmentShader: this.createFragmentShader(textureNames),
+    const material = new THREE.MeshLambertMaterial({
       side: THREE.DoubleSide,
-      transparent: false,
       depthTest: true,
-      depthWrite: true
+      depthWrite: true,
+      fog: true,
     });
-  }
 
-  /**
-   * VS: передаємо бленди + worldXZ для world-locked UV.
-   */
-  private createVertexShader(textureNames: string[]): string {
-    let attributes = '';
-    let varyings = '';
-
-    for (const name of textureNames) {
-      attributes += `attribute float blend_${name};\n`;
-      varyings   += `varying float v_blend_${name};\n`;
+    if (textureNames.length === 0) {
+      return material;
     }
 
-    return `
-      ${attributes}
-      ${varyings}
-      varying vec2 vWorldXZ;
+    material.onBeforeCompile = (shader) => {
+      const attributeDecl = textureNames.map((name) => `attribute float blend_${name};`).join('\n');
+      const varyingDeclVertex = [
+        'varying vec2 vWorldXZ;',
+        ...textureNames.map((name) => `varying float v_blend_${name};`),
+      ].join('\n');
+      const varyingDeclFragment = varyingDeclVertex;
+      const uniformDecl = textureNames
+        .map((name) => `uniform sampler2D texture_${name};\nuniform vec2 tiling_${name};`)
+        .join('\n');
 
-      void main() {
-        // Світові XZ (для world-locked UV)
-        vec4 wpos = modelMatrix * vec4(position, 1.0);
-        vWorldXZ = wpos.xz;
-
-        ${textureNames.map(name => `v_blend_${name} = blend_${name};`).join('\n')}
-
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `;
-  }
-
-  /**
-   * FS: семпл текстур за світовими координатами (repeat), лінійний мікс за блендами.
-   * tiling_* — «повторів на 1 світову одиницю» (тобто просто множимо на vWorldXZ).
-   */
-  private createFragmentShader(textureNames: string[]): string {
-    let uniforms = '';
-    let varyings = '';
-    let body = `vec4 finalColor = vec4(0.0);\nfloat sumW = 0.0;\n`;
-
-    for (const name of textureNames) {
-      uniforms += `uniform sampler2D texture_${name};\n`;
-      uniforms += `uniform vec2 tiling_${name};\n`;
-      varyings += `varying float v_blend_${name};\n`;
-    }
-
-    for (const name of textureNames) {
-      body += `
-        {
+      const blendLogic = [
+        'vec4 terrainColor = vec4(0.0);',
+        'float terrainWeight = 0.0;',
+        ...textureNames.map((name) => `{
           vec2 uv = vWorldXZ * tiling_${name};
-          vec4 s  = texture2D(texture_${name}, uv);
-          float w = max(0.0, v_blend_${name});
-          finalColor += s * w;
-          sumW += w;
+          vec4 sampleColor = texture2D(texture_${name}, uv);
+          float weight = max(0.0, v_blend_${name});
+          terrainColor += sampleColor * weight;
+          terrainWeight += weight;
+        }`),
+        'if (terrainWeight > 1e-5) {',
+        '  terrainColor /= terrainWeight;',
+        '} else {',
+        '  terrainColor = vec4(1.0);',
+        '}',
+        'diffuseColor *= terrainColor;',
+      ].join('\n');
+
+      shader.vertexShader = shader.vertexShader
+        .replace('#include <common>', `#include <common>\n${attributeDecl}\n${varyingDeclVertex}`)
+        .replace(
+          '#include <begin_vertex>',
+          `#include <begin_vertex>\n${textureNames
+            .map((name) => `v_blend_${name} = blend_${name};`)
+            .join('\n')}`,
+        )
+        .replace('#include <worldpos_vertex>', '#include <worldpos_vertex>\nvWorldXZ = worldPosition.xz;');
+
+      shader.fragmentShader = shader.fragmentShader
+        .replace('#include <common>', `#include <common>\n${varyingDeclFragment}\n${uniformDecl}`)
+        .replace('vec4 diffuseColor = vec4( diffuse, opacity );', `vec4 diffuseColor = vec4( diffuse, opacity );\n${blendLogic}`);
+
+      for (const name of textureNames) {
+        const texture = this.textureManager.getTexture(name);
+        if (texture) {
+          texture.wrapS = THREE.RepeatWrapping;
+          texture.wrapT = THREE.RepeatWrapping;
+          texture.needsUpdate = true;
         }
-      `;
-    }
 
-    body += `
-      if (sumW > 1e-5) finalColor /= sumW;
-      gl_FragColor = finalColor;
-    `;
+        shader.uniforms[`texture_${name}`] = { value: texture ?? null };
 
-    return `
-      ${uniforms}
-      ${varyings}
-      varying vec2 vWorldXZ;
-
-      void main(){
-        ${body}
+        const tiling = texturesConfig[name]?.tiling;
+        shader.uniforms[`tiling_${name}`] = {
+          value: new THREE.Vector2(tiling?.x ?? 1, tiling?.y ?? 1),
+        };
       }
-    `;
+    };
+
+    return material;
   }
 
   // -------------------------
@@ -365,6 +340,6 @@ export class TerrainRenderer {
       this.terrainMesh = null;
     }
     
-    // TextureManager очищається автоматично
+    this.textureManager.dispose();
   }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/TextureManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/TextureManager.ts
@@ -4,9 +4,9 @@ import { MAP_CONFIG } from '@systems/map/map-config';
 export class TextureManager {
     private textures: Map<string, THREE.Texture> = new Map();
     private textureLoader: THREE.TextureLoader;
-    
-    constructor() {
-        this.textureLoader = new THREE.TextureLoader();
+
+    constructor(loadingManager?: THREE.LoadingManager) {
+        this.textureLoader = new THREE.TextureLoader(loadingManager);
         this.loadTextures();
     }
     
@@ -95,14 +95,14 @@ export class TextureManager {
     getTexture(textureName: string): THREE.Texture | undefined {
         return this.textures.get(textureName);
     }
-    
+
     /**
      * Отримує всі завантажені текстури
      */
     getAllTextures(): Map<string, THREE.Texture> {
         return this.textures;
     }
-    
+
     /**
      * Перевіряє чи всі текстури завантажені
      */
@@ -116,5 +116,12 @@ export class TextureManager {
         const actualTextureCount = this.textures.size;
         
         return actualTextureCount === expectedTextureCount;
+    }
+
+    dispose(): void {
+        for (const texture of this.textures.values()) {
+            texture.dispose();
+        }
+        this.textures.clear();
     }
 }

--- a/src/ui/screens/colony/scene/components/SceneLoadingOverlay.css
+++ b/src/ui/screens/colony/scene/components/SceneLoadingOverlay.css
@@ -1,0 +1,84 @@
+.scene-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 12, 16, 0.72);
+  backdrop-filter: blur(4px);
+  z-index: 10;
+}
+
+.scene-loading-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 40px;
+  border-radius: 16px;
+  background: rgba(18, 22, 30, 0.9);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+  min-width: 320px;
+  color: #f0f4ff;
+  text-align: center;
+}
+
+.scene-loading-spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid rgba(240, 244, 255, 0.25);
+  border-top-color: #7ec7ff;
+  animation: scene-loading-spin 1s linear infinite;
+}
+
+.scene-loading-title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.scene-loading-progress-bar {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+}
+
+.scene-loading-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #58a6ff, #8b5cf6);
+  transition: width 0.25s ease;
+}
+
+.scene-loading-progress-label {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.scene-loading-message {
+  font-size: 14px;
+  color: rgba(240, 244, 255, 0.8);
+  max-width: 320px;
+}
+
+.scene-loading-errors {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #ffb4a2;
+  max-height: 120px;
+  overflow-y: auto;
+  width: 100%;
+  text-align: left;
+}
+
+@keyframes scene-loading-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/ui/screens/colony/scene/components/SceneLoadingOverlay.tsx
+++ b/src/ui/screens/colony/scene/components/SceneLoadingOverlay.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import './SceneLoadingOverlay.css';
+
+interface SceneLoadingOverlayProps {
+  progress: number;
+  message?: string;
+  errors?: string[];
+}
+
+export const SceneLoadingOverlay: React.FC<SceneLoadingOverlayProps> = ({
+  progress,
+  message,
+  errors,
+}) => {
+  const percentage = Math.round(progress * 100);
+  const hasErrors = errors && errors.length > 0;
+
+  return (
+    <div className="scene-loading-overlay">
+      <div className="scene-loading-card">
+        <div className="scene-loading-spinner" />
+        <div className="scene-loading-title">Завантаження сцени</div>
+        <div className="scene-loading-progress-bar">
+          <div
+            className="scene-loading-progress-fill"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+        <div className="scene-loading-progress-label">
+          {percentage}%
+        </div>
+        {message && (
+          <div className="scene-loading-message">{message}</div>
+        )}
+        {hasErrors && (
+          <div className="scene-loading-errors">
+            {errors?.map((err, idx) => (
+              <div key={`${err}-${idx}`}>{err}</div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/screens/colony/scene/hooks/useBuildingPreview.ts
+++ b/src/ui/screens/colony/scene/hooks/useBuildingPreview.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { BuildingPreview } from '@ui/screens/colony/scene/renderers/BuildingPreview';
 import { IMapLogic } from '@interfaces/index';
 
-export function useBuildingPreview(scene: THREE.Scene, mapLogic: IMapLogic) {
+export function useBuildingPreview(scene: THREE.Scene, mapLogic: IMapLogic, loadingManager?: THREE.LoadingManager) {
   const buildingPreviewRef = useRef<BuildingPreview | null>(null);
   const mapLogicRef = useRef(mapLogic);
   const [isReady, setIsReady] = useState(false);
@@ -15,7 +15,7 @@ export function useBuildingPreview(scene: THREE.Scene, mapLogic: IMapLogic) {
 
   useEffect(() => {
     // Створюємо BuildingPreview
-    buildingPreviewRef.current = new BuildingPreview(scene);
+    buildingPreviewRef.current = new BuildingPreview(scene, loadingManager);
 
     // Попередньо завантажуємо моделі будівель
     const buildingTypes = Array.from(mapLogicRef.current.buildingsManager.getAllBuildingTypes().values());
@@ -27,7 +27,7 @@ export function useBuildingPreview(scene: THREE.Scene, mapLogic: IMapLogic) {
       buildingPreviewRef.current = null;
       setIsReady(false);
     };
-  }, [scene]); // Видалили mapLogic з залежностей, використовуємо ref
+  }, [scene, loadingManager]); // Видалили mapLogic з залежностей, використовуємо ref
 
   return { buildingPreviewRef, isReady };
 }

--- a/src/ui/screens/colony/scene/hooks/useSceneCore.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneCore.ts
@@ -7,9 +7,19 @@ export function useSceneCore() {
     s.background = new THREE.Color('#5a4f2e');
 
     const ambient = new THREE.AmbientLight(0xf0f0c0, 0.6);
-    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
-    dir.position.set(50, 100, 50);
-    dir.castShadow = false;
+    const dir = new THREE.DirectionalLight(0xffffff, 0.85);
+    dir.position.set(80, 120, 60);
+    dir.castShadow = true;
+    dir.shadow.mapSize.set(2048, 2048);
+    dir.shadow.bias = -0.0005;
+
+    const shadowCam = dir.shadow.camera as THREE.OrthographicCamera;
+    shadowCam.left = -220;
+    shadowCam.right = 220;
+    shadowCam.top = 220;
+    shadowCam.bottom = -220;
+    shadowCam.near = 10;
+    shadowCam.far = 400;
     s.add(ambient, dir);
 
     (s as THREE.Scene & {

--- a/src/ui/screens/colony/scene/hooks/useSceneManagers.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneManagers.ts
@@ -6,12 +6,14 @@ import { TerrainRenderer } from '@ui/screens/colony/scene/Scene3D/renderers/Terr
 import { AreaSelectionRenderer } from '@ui/screens/colony/scene/AreaSelectionRenderer';
 import { createUiLogicBridge } from '@ui/logic/UiLogicBridge';
 import { IMapLogic } from '@interfaces/index';
+import { SceneLoadingManager } from '../Scene3D/loading/SceneLoadingManager';
 
 export function useSceneManagers(
   scene: THREE.Scene,
   camera: THREE.PerspectiveCamera,
   renderer: THREE.WebGLRenderer,
-  appMapLogic: IMapLogic
+  appMapLogic: IMapLogic,
+  loadingManager?: SceneLoadingManager
 ) {
   const rendererManagerRef = useRef<RendererManager | null>(null);
   const selectionRendererRef = useRef<SelectionRenderer | null>(null);
@@ -22,7 +24,8 @@ export function useSceneManagers(
 
   useEffect(() => {
     const bridge = createUiLogicBridge(appMapLogic);
-    rendererManagerRef.current = new RendererManager(scene, renderer, bridge);
+    const manager = loadingManager?.getLoadingManager();
+    rendererManagerRef.current = new RendererManager(scene, renderer, bridge, manager);
     mapLogicRef.current = appMapLogic;
 
     selectionRendererRef.current = new SelectionRenderer(
@@ -33,14 +36,16 @@ export function useSceneManagers(
 
     const tm = mapLogicRef.current.scene.getTerrainManager();
     if (tm) {
-      terrainRendererRef.current = new TerrainRenderer(scene, tm);
-      terrainRendererRef.current
+      terrainRendererRef.current = new TerrainRenderer(scene, tm, manager);
+      const initialRender = terrainRendererRef.current
         .renderTerrain({
           x: camera.position.x,
           y: camera.position.y,
           z: camera.position.z,
         })
         .catch((e) => console.error('Failed to render initial terrain:', e));
+
+      loadingManager?.trackPromise(initialRender);
     }
 
     setManagersReady(true);
@@ -56,7 +61,7 @@ export function useSceneManagers(
 
       setManagersReady(false);
     };
-  }, [scene, camera, renderer, appMapLogic]);
+  }, [scene, camera, renderer, appMapLogic, loadingManager]);
 
   return {
     rendererManagerRef,

--- a/src/ui/screens/colony/scene/renderers/BuildingPreview.ts
+++ b/src/ui/screens/colony/scene/renderers/BuildingPreview.ts
@@ -13,9 +13,9 @@ export class BuildingPreview {
   private isPlacementValid: boolean = true;
   private originalMaterials: Map<string, { color: THREE.Color; opacity: number }> = new Map();
 
-  constructor(scene: THREE.Scene) {
+  constructor(scene: THREE.Scene, loadingManager?: THREE.LoadingManager) {
     this.scene = scene;
-    this.gltfLoader = new GLTFLoader();
+    this.gltfLoader = new GLTFLoader(loadingManager ?? undefined);
   }
 
   public show(position: { x: number; y: number; z: number }, buildingData: any): void {


### PR DESCRIPTION
## Summary
- add a reusable scene loading manager and overlay so the 3D view waits for terrain, textures and models
- connect the loading manager to terrain, renderer and building loaders while enabling building fallback shadows
- switch the terrain material to a lit shader, configure directional shadows and clean up texture resources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1941d4b8c8320924c21aebce9b0d2