### PR TITLE
Implement day/night cycle with global time HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 // import { Scene3D } from '@ui/screens/colony/scene/Scene3D';
 import { MainMenu, Scene3D } from './ui';
 import { ResourcesBar } from '@ui/screens/colony/ui-controls/ResourcesBar';
+import { GlobalTimeDisplay } from '@ui/screens/colony/ui-controls/GlobalTimeDisplay';
 import { Game } from '@core/game/game';
 import './App.css';
 import type { IMapLogic } from '@interfaces/index';
@@ -48,6 +49,7 @@ function App() {
       ) : (
         <>
           <ResourcesBar resourceManager={game.mapLogic.resources} />
+          <GlobalTimeDisplay environment={game.mapLogic.environment} />
           <Scene3D
             saveManager={game.saveManager}
             onShowMainMenu={handleShowMainMenu}

--- a/src/logic/modules/buildings/BuildingsManager.ts
+++ b/src/logic/modules/buildings/BuildingsManager.ts
@@ -372,10 +372,6 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
     return this.buildingInstances.get(instanceId);
   }
 
-  private isBuiltComputed(inst: BuildingInstance): boolean {
-    return inst.built !== false && inst.level > 0;
-  }
-
   private getBonusSourceId(typeId: BuildingTypeId): string {
     return `building_source_${typeId}`;
   }

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -1,48 +1,162 @@
-import { AuroraEffect, EnvironmentConfig, IEnvironmentEffect } from "./environment.types";
+import { SceneLogic } from '@scene/scene-logic';
+import { TSceneObject } from '@scene/scene.types';
+import {
+  AuroraEffect,
+  EnvironmentConfig,
+  EnvironmentState,
+  IEnvironmentEffect,
+  SunLightState,
+} from './environment.types';
 
 /**
- * Логіка управління енвайронмент-ефектами (полярне сяйво, погода, тощо)
+ * Базова конфігурація енвайронменту
+ */
+const DEFAULT_CONFIG: EnvironmentConfig = {
+  aurora: {
+    minIntensity: 0.2,
+    maxIntensity: 0.5,
+    minDuration: 30,
+    maxDuration: 120,
+    spawnChance: 0.1,
+    maxActiveEffects: 3,
+  },
+  updateInterval: 1000,
+  timeOfDay: 0,
+  mapSize: {
+    width: 600,
+    depth: 600,
+  },
+  time: {
+    dayLengthMinutes: 24,
+    sunriseHour: 6,
+    sunsetHour: 18,
+    twilightDurationHours: 1,
+    initialHour: 12,
+    initialMinute: 0,
+  },
+  weather: {
+    temperature: {
+      min: -50,
+      max: 20,
+    },
+    windSpeed: {
+      min: 2,
+      max: 18,
+      changeIntervalHours: 3,
+      transitionSeconds: 12,
+    },
+  },
+  dustClouds: {
+    initialCount: 2,
+    spawnIntervalSeconds: 60,
+    ttlSeconds: 60,
+    fadeDurationSeconds: 15,
+    size: { min: 21, max: 43 },
+    height: { min: 4, max: 12 },
+    windSpeed: { min: 0.3, max: 1.0 },
+    particleCount: 200,
+    color: 0xd2b46c,
+  },
+};
+
+/**
+ * Логіка управління енвайронмент-ефектами (полярне сяйво, погода, добовий цикл)
  */
 export class EnvironmentLogic {
+  private readonly scene: SceneLogic;
   private config: EnvironmentConfig;
-  private activeEffects: Map<string, IEnvironmentEffect> = new Map();
-  private lastUpdateTime: number = 0;
-  private effectIdCounter: number = 0;
 
-  constructor(config?: Partial<EnvironmentConfig>) {
-    this.config = {
-      aurora: {
-        minIntensity: 0.2,
-        maxIntensity: 0.5,
-        minDuration: 30, // 30 секунд
-        maxDuration: 120, // 2 хвилини
-        spawnChance: 0.1, // 10% шанс за хвилину
-        maxActiveEffects: 3
-      },
-      updateInterval: 1000, // оновлення кожну секунду
-      timeOfDay: 0.0, // північ
-      ...config
-    };
+  private activeEffects: Map<string, IEnvironmentEffect> = new Map();
+  private lastUpdateTime = 0;
+  private effectIdCounter = 0;
+
+  private dustCloudTimer = 0;
+  private dustCloudIdCounter = 0;
+  private dustClouds: Map<string, { createdAt: number; ttl: number }> = new Map();
+
+  private initialized = false;
+
+  private time = {
+    totalMinutes: 0,
+    currentMinutes: 0,
+    currentDay: 1,
+  };
+
+  private weather = {
+    temperature: 0,
+    windSpeed: 0,
+    windTarget: 0,
+    nextWindChangeMinute: 0,
+  };
+
+  private state: EnvironmentState;
+
+  private readonly gameMinutesPerRealSecond: number;
+
+  constructor(scene: SceneLogic, config?: Partial<EnvironmentConfig>) {
+    this.scene = scene;
+    this.config = this.mergeConfig(DEFAULT_CONFIG, config);
+
+    this.gameMinutesPerRealSecond = 24 / this.config.time.dayLengthMinutes;
+
+    this.time.totalMinutes = this.config.time.initialHour * 60 + this.config.time.initialMinute;
+    this.updateTimeFromTotalMinutes();
+
+    const windRange = this.config.weather.windSpeed;
+    this.weather.temperature = this.calculateTemperature();
+    this.weather.windSpeed = this.randomBetween(windRange.min, windRange.max);
+    this.weather.windTarget = this.weather.windSpeed;
+    this.weather.nextWindChangeMinute =
+      this.time.totalMinutes + windRange.changeIntervalHours * 60;
+
+    this.state = this.buildEnvironmentState();
   }
 
   /**
-   * Оновлення логіки ефектів
+   * Ініціалізує енвайронмент для нового світу
    */
-  update(): void {
-    const now = Date.now();
-    
-    // Оновлюємо не частіше ніж кожні updateInterval мс
-    if (now - this.lastUpdateTime < this.config.updateInterval) {
-      return;
+  initialize(): void {
+    this.initialized = true;
+    this.clearAllEffects();
+    this.clearDustClouds();
+    this.dustCloudTimer = 0;
+
+    const startTotalMinutes =
+      this.config.time.initialHour * 60 + this.config.time.initialMinute;
+    this.time.totalMinutes = startTotalMinutes;
+    this.updateTimeFromTotalMinutes();
+
+    const windRange = this.config.weather.windSpeed;
+    this.weather.temperature = this.calculateTemperature();
+    this.weather.windSpeed = this.randomBetween(windRange.min, windRange.max);
+    this.weather.windTarget = this.weather.windSpeed;
+    this.weather.nextWindChangeMinute =
+      this.time.totalMinutes + windRange.changeIntervalHours * 60;
+
+    this.generateInitialDustClouds();
+    this.state = this.buildEnvironmentState();
+  }
+
+  /**
+   * Оновлення логіки енвайронменту
+   */
+  update(deltaTimeSeconds: number): void {
+    if (!this.initialized) {
+      this.initialize();
     }
-    
-    this.lastUpdateTime = now;
-    
-    // Видаляємо застарілі ефекти
-    this.cleanupExpiredEffects(now);
-    
-    // Генеруємо нові ефекти
-    this.generateNewEffects(now);
+
+    this.advanceTime(deltaTimeSeconds);
+    this.updateWeather(deltaTimeSeconds);
+    this.updateDustClouds(deltaTimeSeconds);
+
+    const now = Date.now();
+    if (now - this.lastUpdateTime >= this.config.updateInterval) {
+      this.lastUpdateTime = now;
+      this.cleanupExpiredEffects(now);
+      this.generateNewEffects(now);
+    }
+
+    this.state = this.buildEnvironmentState();
   }
 
   /**
@@ -56,15 +170,42 @@ export class EnvironmentLogic {
    * Отримати тільки полярні сяйва
    */
   getAuroraEffects(): AuroraEffect[] {
-    return this.getActiveEffects()
-      .filter(effect => effect.type === 'aurora') as AuroraEffect[];
+    return this.getActiveEffects().filter((effect) => effect.type === 'aurora') as AuroraEffect[];
+  }
+
+  /**
+   * Отримати стан середовища (день, час, погода)
+   */
+  getEnvironmentState(): EnvironmentState {
+    return {
+      ...this.state,
+      time: { ...this.state.time },
+      sun: {
+        ...this.state.sun,
+        direction: { ...this.state.sun.direction },
+      },
+    };
+  }
+
+  /**
+   * Стан сонячного світла для рендера
+   */
+  getSunLightState(): SunLightState {
+    return {
+      ...this.state.sun,
+      direction: { ...this.state.sun.direction },
+    };
   }
 
   /**
    * Встановити час доби (0.0 = північ, 0.5 = полудень, 1.0 = північ)
    */
   setTimeOfDay(timeOfDay: number): void {
-    this.config.timeOfDay = Math.max(0, Math.min(1, timeOfDay));
+    const clamped = this.clamp(timeOfDay, 0, 1);
+    const baseDay = Math.floor(this.time.totalMinutes / 1440) * 1440;
+    this.time.totalMinutes = baseDay + clamped * 1440;
+    this.updateTimeFromTotalMinutes();
+    this.state = this.buildEnvironmentState();
   }
 
   /**
@@ -75,11 +216,17 @@ export class EnvironmentLogic {
   }
 
   /**
-   * Чи є зараз "ніч" (полярне сяйво видиме)
+   * Чи є зараз ніч
    */
   isNightTime(): boolean {
-    // Полярне сяйво видиме вночі (0.0-0.25 та 0.75-1.0)
-    return this.config.timeOfDay < 0.25 || this.config.timeOfDay > 0.75;
+    const sunriseMinutes = this.config.time.sunriseHour * 60;
+    const sunsetMinutes = this.config.time.sunsetHour * 60;
+    const twilightMinutes = this.config.time.twilightDurationHours * 60;
+    const dawnStart = sunriseMinutes - twilightMinutes;
+    const duskEnd = sunsetMinutes + twilightMinutes;
+    const minutes = this.time.currentMinutes;
+
+    return minutes < dawnStart || minutes >= duskEnd;
   }
 
   /**
@@ -100,9 +247,110 @@ export class EnvironmentLogic {
   //        Приватні методи
   // ──────────────────────────────
 
+  private mergeConfig(base: EnvironmentConfig, overrides?: Partial<EnvironmentConfig>): EnvironmentConfig {
+    if (!overrides) {
+      return base;
+    }
+
+    const merged: EnvironmentConfig = {
+      ...base,
+      ...overrides,
+      aurora: { ...base.aurora, ...(overrides.aurora ?? {}) },
+      mapSize: { ...base.mapSize, ...(overrides.mapSize ?? {}) },
+      time: { ...base.time, ...(overrides.time ?? {}) },
+      weather: {
+        temperature: {
+          ...base.weather.temperature,
+          ...(overrides.weather?.temperature ?? {}),
+        },
+        windSpeed: {
+          ...base.weather.windSpeed,
+          ...(overrides.weather?.windSpeed ?? {}),
+        },
+      },
+      dustClouds: {
+        ...base.dustClouds,
+        ...(overrides.dustClouds ?? {}),
+        size: {
+          ...base.dustClouds.size,
+          ...(overrides.dustClouds?.size ?? {}),
+        },
+        height: {
+          ...base.dustClouds.height,
+          ...(overrides.dustClouds?.height ?? {}),
+        },
+        windSpeed: {
+          ...base.dustClouds.windSpeed,
+          ...(overrides.dustClouds?.windSpeed ?? {}),
+        },
+      },
+    };
+
+    return merged;
+  }
+
+  private advanceTime(deltaTimeSeconds: number): void {
+    const minutesAdvance = deltaTimeSeconds * this.gameMinutesPerRealSecond;
+    this.time.totalMinutes += minutesAdvance;
+    this.updateTimeFromTotalMinutes();
+  }
+
+  private updateTimeFromTotalMinutes(): void {
+    this.time.currentDay = Math.floor(this.time.totalMinutes / 1440) + 1;
+    const minutesInDay = this.time.totalMinutes % 1440;
+    this.time.currentMinutes = minutesInDay;
+    this.config.timeOfDay = minutesInDay / 1440;
+  }
+
+  private updateWeather(deltaTimeSeconds: number): void {
+    this.weather.temperature = this.calculateTemperature();
+
+    const windConfig = this.config.weather.windSpeed;
+    if (
+      windConfig.changeIntervalHours > 0 &&
+      this.time.totalMinutes >= this.weather.nextWindChangeMinute
+    ) {
+      this.weather.windTarget = this.randomBetween(windConfig.min, windConfig.max);
+      this.weather.nextWindChangeMinute =
+        this.time.totalMinutes + windConfig.changeIntervalHours * 60;
+    }
+
+    const diff = this.weather.windTarget - this.weather.windSpeed;
+    if (Math.abs(diff) > 0.001) {
+      const transition = Math.max(0.1, windConfig.transitionSeconds);
+      const step = Math.min(1, deltaTimeSeconds / transition);
+      this.weather.windSpeed += diff * step;
+      if (diff > 0) {
+        this.weather.windSpeed = Math.min(this.weather.windSpeed, windConfig.max);
+      } else {
+        this.weather.windSpeed = Math.max(this.weather.windSpeed, windConfig.min);
+      }
+    }
+  }
+
+  private updateDustClouds(deltaTimeSeconds: number): void {
+    const cfg = this.config.dustClouds;
+    if (!cfg) return;
+
+    this.dustCloudTimer += deltaTimeSeconds;
+    if (this.dustCloudTimer >= cfg.spawnIntervalSeconds) {
+      this.generateDustCloud();
+      this.dustCloudTimer = 0;
+    }
+
+    const now = Date.now() / 1000;
+    for (const [cloudId, data] of this.dustClouds) {
+      const age = now - data.createdAt;
+      if (age >= data.ttl) {
+        this.scene.removeObject(cloudId);
+        this.dustClouds.delete(cloudId);
+      }
+    }
+  }
+
   private cleanupExpiredEffects(now: number): void {
     for (const [id, effect] of this.activeEffects.entries()) {
-      const elapsed = (now - effect.startTime) / 1000; // секунди
+      const elapsed = (now - effect.startTime) / 1000;
       if (elapsed >= effect.duration) {
         this.activeEffects.delete(id);
       }
@@ -110,7 +358,6 @@ export class EnvironmentLogic {
   }
 
   private generateNewEffects(now: number): void {
-    // Генеруємо полярне сяйво тільки вночі
     if (this.isNightTime()) {
       this.generateAuroraEffect(now);
     }
@@ -118,19 +365,15 @@ export class EnvironmentLogic {
 
   private generateAuroraEffect(now: number): void {
     const auroraConfig = this.config.aurora;
-    
-    // Перевіряємо чи не забагато активних ефектів
     const currentAuroraCount = this.getAuroraEffects().length;
     if (currentAuroraCount >= auroraConfig.maxActiveEffects) {
       return;
     }
 
-    // Випадковий шанс генерації
-    if (Math.random() > 60*auroraConfig.spawnChance / 60) { // нормалізуємо до секунди
+    if (Math.random() > auroraConfig.spawnChance) {
       return;
     }
 
-    // Генеруємо нове полярне сяйво
     const aurora: AuroraEffect = {
       id: `aurora_${++this.effectIdCounter}`,
       type: 'aurora',
@@ -138,49 +381,174 @@ export class EnvironmentLogic {
       position: this.generateAuroraPosition(),
       duration: this.randomBetween(auroraConfig.minDuration, auroraConfig.maxDuration),
       startTime: now,
-      
-      // Кольори полярного сяйва
       primaryColor: this.generateAuroraColor(),
       secondaryColor: this.generateAuroraColor(),
-      
-      // Параметри руху
       waveSpeed: this.randomBetween(0.5, 2.0),
       waveAmplitude: this.randomBetween(0.3, 0.8),
-      
-      // Розміри
       width: this.randomBetween(350, 750),
       height: this.randomBetween(160, 320),
-      
-      // Напрямок руху
-      direction: Math.random() * Math.PI * 2
+      direction: Math.random() * Math.PI * 2,
     };
-    console.log('AuroraGenerated: ', aurora);
+
     this.activeEffects.set(aurora.id, aurora);
   }
 
   private generateAuroraPosition(): { x: number; y: number; z: number } {
-    // Полярне сяйво з'являється на фіксованій відстані 400 від центру
-    const distance = 400; // фіксована відстань від центру
-    const azimuth = Math.random() * Math.PI * 2; // рандомізований азимутальний кут (0-2π)
-    
+    const distance = 400;
+    const azimuth = Math.random() * Math.PI * 2;
+
     return {
-      x: Math.cos(azimuth) * distance, // X координата на колі
-      y: this.randomBetween(10, 40),   // високо в небі
-      z: Math.sin(azimuth) * distance   // Z координата на колі
+      x: Math.cos(azimuth) * distance,
+      y: this.randomBetween(10, 40),
+      z: Math.sin(azimuth) * distance,
     };
   }
 
   private generateAuroraColor(): { r: number; g: number; b: number } {
-    // Типові кольори полярного сяйва
     const colors = [
-      { r: 0.0, g: 1.0, b: 0.5 },   // зелений
-      { r: 0.0, g: 0.8, b: 1.0 },   // блакитний
-      { r: 0.7, g: 0.6, b: 1.0 },   // фіолетовий
-      { r: 1.0, g: 1.0, b: 0.0 },   // жовтий
-      { r: 0.5, g: 0.0, b: 1.0 }    // синій
+      { r: 0.0, g: 1.0, b: 0.5 },
+      { r: 0.0, g: 0.8, b: 1.0 },
+      { r: 0.7, g: 0.6, b: 1.0 },
+      { r: 1.0, g: 1.0, b: 0.0 },
+      { r: 0.5, g: 0.0, b: 1.0 },
     ];
-    
+
     return colors[Math.floor(Math.random() * colors.length)];
+  }
+
+  private generateInitialDustClouds(): void {
+    const count = this.config.dustClouds.initialCount;
+    for (let i = 0; i < count; i++) {
+      this.generateDustCloud();
+    }
+  }
+
+  private generateDustCloud(): void {
+    const cfg = this.config.dustClouds;
+    const mapWidth = this.config.mapSize.width;
+    const mapDepth = this.config.mapSize.depth;
+
+    const cloudId = `dust_cloud_${++this.dustCloudIdCounter}`;
+    const x = (Math.random() - 0.5) * mapWidth;
+    const z = (Math.random() - 0.5) * mapDepth;
+    const createdAt = Date.now() / 1000;
+    const ttl = cfg.ttlSeconds;
+
+    const cloud: TSceneObject = {
+      id: cloudId,
+      type: 'cloud',
+      coordinates: { x, y: 0, z },
+      scale: { x: 1, y: 1, z: 1 },
+      rotation: { x: 0, y: 0, z: 0 },
+      speed: {
+        x: (Math.random() - 0.5) * 1.5,
+        y: 0,
+        z: (Math.random() - 0.5) * 1.5,
+      },
+      data: {
+        size: this.randomBetween(cfg.size.min, cfg.size.max),
+        color: cfg.color,
+        particleCount: cfg.particleCount,
+        windSpeed: this.randomBetween(cfg.windSpeed.min, cfg.windSpeed.max),
+        height: this.randomBetween(cfg.height.min, cfg.height.max),
+      },
+      tags: ['on-ground', 'dust', 'dynamic'],
+      bottomAnchor: -1,
+      terrainAlign: false,
+    };
+
+    this.scene.pushObjectWithTerrainConstraint(cloud);
+    this.dustClouds.set(cloudId, { createdAt, ttl });
+  }
+
+  private clearDustClouds(): void {
+    for (const cloudId of this.dustClouds.keys()) {
+      this.scene.removeObject(cloudId);
+    }
+    this.dustClouds.clear();
+    this.dustCloudIdCounter = 0;
+  }
+
+  private buildEnvironmentState(): EnvironmentState {
+    const minutes = this.time.currentMinutes;
+    const hour = Math.floor(minutes / 60);
+    const minute = Math.floor(minutes % 60);
+    const sun = this.calculateSunLightState();
+
+    return {
+      day: this.time.currentDay,
+      time: {
+        hour,
+        minute,
+        totalMinutes: minutes,
+        formatted: `${hour.toString().padStart(2, '0')}:${minute
+          .toString()
+          .padStart(2, '0')}`,
+      },
+      temperature: this.weather.temperature,
+      windSpeed: this.weather.windSpeed,
+      isNight: this.isNightTime(),
+      sun,
+    };
+  }
+
+  private calculateTemperature(): number {
+    const { min, max } = this.config.weather.temperature;
+    const dayProgress = (this.time.currentMinutes % 1440) / 1440;
+    const normalized = (Math.cos((dayProgress - 0.5) * 2 * Math.PI) + 1) / 2;
+    return min + normalized * (max - min);
+  }
+
+  private calculateSunLightState(): SunLightState {
+    const { sunriseHour, sunsetHour, twilightDurationHours } = this.config.time;
+    const sunriseMinutes = sunriseHour * 60;
+    const sunsetMinutes = sunsetHour * 60;
+    const twilightMinutes = twilightDurationHours * 60;
+    const dawnStart = sunriseMinutes - twilightMinutes;
+    const duskEnd = sunsetMinutes + twilightMinutes;
+    const minutes = this.time.currentMinutes;
+
+    let intensity = 0;
+    if (minutes >= dawnStart && minutes < sunriseMinutes) {
+      const t = (minutes - dawnStart) / Math.max(1, sunriseMinutes - dawnStart);
+      intensity = this.easeInOut(t) * 0.5;
+    } else if (minutes >= sunriseMinutes && minutes <= sunsetMinutes) {
+      const dayRange = Math.max(1, sunsetMinutes - sunriseMinutes);
+      const t = (minutes - sunriseMinutes) / dayRange;
+      intensity = 0.5 + Math.sin(t * Math.PI) * 0.5;
+    } else if (minutes > sunsetMinutes && minutes < duskEnd) {
+      const t = (duskEnd - minutes) / Math.max(1, duskEnd - sunsetMinutes);
+      intensity = this.easeInOut(t) * 0.5;
+    } else {
+      intensity = 0;
+    }
+
+    intensity = this.clamp(intensity, 0, 1);
+    const ambientIntensity = 0.18 + intensity * 0.35;
+
+    const fullProgress = this.time.currentMinutes / 1440;
+    const orbitAngle = (fullProgress - 0.25) * 2 * Math.PI;
+    const radius = Math.max(this.config.mapSize.width, this.config.mapSize.depth) * 0.6;
+    const direction = {
+      x: Math.cos(orbitAngle) * radius,
+      y: Math.max(30, Math.sin(orbitAngle) * radius * 0.8),
+      z: Math.sin(orbitAngle * 0.5) * radius * 0.4,
+    };
+
+    return {
+      direction,
+      directionalIntensity: intensity,
+      ambientIntensity,
+    };
+  }
+
+  private easeInOut(value: number): number {
+    const t = this.clamp(value, 0, 1);
+    return Math.sin((t * Math.PI) / 2);
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
   }
 
   private randomBetween(min: number, max: number): number {

--- a/src/logic/systems/environment/environment.types.ts
+++ b/src/logic/systems/environment/environment.types.ts
@@ -17,29 +17,92 @@ export interface IEnvironmentEffect {
  */
 export interface AuroraEffect extends IEnvironmentEffect {
   type: 'aurora';
-  
+
   // Позиція на фіксованій відстані 400 від центру з рандомізованим азимутальним кутом
   position: Vector3; // x = cos(azimuth) * 400, z = sin(azimuth) * 400, y = random(10, 40)
-  
+
   // Кольори сяйва (RGB 0-1)
   // Доступні кольори: зелений, блакитний, фіолетовий, жовтий, синій
   primaryColor: { r: number; g: number; b: number };
   secondaryColor: { r: number; g: number; b: number };
-  
+
   // Параметри руху
   waveSpeed: number; // швидкість хвиль
   waveAmplitude: number; // амплітуда хвиль
-  
+
   // Розміри
   width: number; // ширина сяйва (350-750)
   height: number; // висота сяйва (160-320)
-  
+
   // Напрямок руху
   direction: number; // радіани
 }
 
+export interface DayNightCycleConfig {
+  dayLengthMinutes: number; // Реальна тривалість доби у хвилинах
+  sunriseHour: number; // година сходу сонця (ігрова)
+  sunsetHour: number;  // година заходу сонця (ігрова)
+  twilightDurationHours: number; // тривалість сутінків до/після сходу та заходу
+  initialHour: number;  // година старту гри
+  initialMinute: number; // хвилина старту гри
+}
+
+export interface TemperatureRangeConfig {
+  min: number;
+  max: number;
+}
+
+export interface WindSpeedConfig {
+  min: number;
+  max: number;
+  changeIntervalHours: number; // як часто міняється цільова швидкість вітру
+  transitionSeconds: number;   // скільки секунд займає перехід до нової швидкості
+}
+
+export interface WeatherConfig {
+  temperature: TemperatureRangeConfig;
+  windSpeed: WindSpeedConfig;
+}
+
+export interface DustCloudConfig {
+  initialCount: number;
+  spawnIntervalSeconds: number;
+  ttlSeconds: number;
+  fadeDurationSeconds: number;
+  size: { min: number; max: number };
+  height: { min: number; max: number };
+  windSpeed: { min: number; max: number };
+  particleCount: number;
+  color: number;
+}
+
+export interface MapSizeConfig {
+  width: number;
+  depth: number;
+}
+
+export interface SunLightState {
+  direction: Vector3;
+  directionalIntensity: number;
+  ambientIntensity: number;
+}
+
+export interface EnvironmentState {
+  day: number;
+  time: {
+    hour: number;
+    minute: number;
+    totalMinutes: number;
+    formatted: string;
+  };
+  temperature: number;
+  windSpeed: number;
+  isNight: boolean;
+  sun: SunLightState;
+}
+
 /**
- * Конфігурація для генерації ефектів
+ * Конфігурація для генерації ефектів та керування погодою/днем-ніччю
  */
 export interface EnvironmentConfig {
   // Полярне сяйво
@@ -48,11 +111,23 @@ export interface EnvironmentConfig {
     maxIntensity: number; // 0.5 - максимальна інтенсивність
     minDuration: number; // секунди
     maxDuration: number;
-    spawnChance: number; // 0.0 - 1.0 за хвилину
+    spawnChance: number; // 0.0 - 1.0 за інтервал оновлення
     maxActiveEffects: number;
   };
-  
+
   // Загальні налаштування
   updateInterval: number; // мілісекунди
   timeOfDay: number; // 0.0 - 1.0 (0 = північ, 0.5 = полудень)
+
+  // Розміри карти для енвайронмент-ефектів
+  mapSize: MapSizeConfig;
+
+  // Параметри циклу день/ніч
+  time: DayNightCycleConfig;
+
+  // Параметри погоди
+  weather: WeatherConfig;
+
+  // Параметри хмар з пилу
+  dustClouds: DustCloudConfig;
 }

--- a/src/logic/systems/environment/index.ts
+++ b/src/logic/systems/environment/index.ts
@@ -1,6 +1,8 @@
 export { EnvironmentLogic } from "./EnvironmentLogic";
-export type { 
-  IEnvironmentEffect, 
-  AuroraEffect, 
-  EnvironmentConfig 
+export type {
+  IEnvironmentEffect,
+  AuroraEffect,
+  EnvironmentConfig,
+  EnvironmentState,
+  SunLightState
 } from "./environment.types";

--- a/src/logic/systems/map/map-config.ts
+++ b/src/logic/systems/map/map-config.ts
@@ -1,3 +1,5 @@
+import type { EnvironmentConfig } from '@systems/environment/environment.types';
+
 // Конфігурація розмірів мапи
 export const MAP_CONFIG = {
     // Розміри світу
@@ -91,6 +93,32 @@ export const MAP_CONFIG = {
                 scale: { x: 1, y: 1, z: 1 }
             }
         }
+    },
+
+    environment: {
+        time: {
+            dayLengthMinutes: 24,
+            sunriseHour: 6,
+            sunsetHour: 18,
+            twilightDurationHours: 1,
+            initialHour: 12,
+            initialMinute: 0,
+        },
+        weather: {
+            temperature: { min: -50, max: 20 },
+            windSpeed: { min: 2, max: 18, changeIntervalHours: 2, transitionSeconds: 12 },
+        },
+        dustClouds: {
+            spawnIntervalSeconds: 60,
+            ttlSeconds: 60,
+            fadeDurationSeconds: 15,
+            initialCount: 2,
+            size: { min: 21, max: 43 },
+            height: { min: 4, max: 12 },
+            windSpeed: { min: 0.3, max: 1.0 },
+            particleCount: 200,
+            color: 0xd2b46c,
+        }
     }
 };
 
@@ -133,4 +161,5 @@ export interface MapConfig {
         spacing: number;
         offset: number;
     };
+    environment?: Partial<EnvironmentConfig>;
 }

--- a/src/logic/systems/map/map-logic.ts
+++ b/src/logic/systems/map/map-logic.ts
@@ -77,11 +77,6 @@ export class MapLogic implements SaveLoadManager {
   // NEW: index for non-overlapping cluster placement (rocks/biomass)
   private clusterIndex: SpatialHash2D | null = null;
 
-  // Система автоматичної генерації хмар
-  private cloudGenerationTimer: number = 0;
-  private cloudGenerationInterval: number = 60000; // 60 секунд
-  private activeClouds: Map<string, { createdAt: number; ttl: number }> = new Map();
-
   // Config for minimal edge-to-edge gap between clusters
   private static readonly CLUSTER_MARGIN = 1.0; // meters
 
@@ -93,7 +88,13 @@ export class MapLogic implements SaveLoadManager {
     this.autoGroupMonitor = new AutoGroupMonitor(this);
     this.collectedRocks = new Set();
     this.collectedBiomass = new Set();
-    this.environment = new EnvironmentLogic();
+    this.environment = new EnvironmentLogic(this.scene, {
+      ...(MAP_CONFIG.environment ?? {}),
+      mapSize: {
+        width: MAP_CONFIG.width,
+        depth: MAP_CONFIG.depth
+      }
+    });
   }
 
   setCommandSystems(commandSystem: CommandSystem, commandGroupSystem: CommandGroupSystem) {
@@ -165,7 +166,7 @@ export class MapLogic implements SaveLoadManager {
     // Then biomass clusters that avoid rock circles with a 1 m margin
     this.generateBiomass();
 
-    this.generateClouds();
+    this.environment.initialize();
     this.scene.rebuildObstacles(true);
   }
 
@@ -615,8 +616,7 @@ export class MapLogic implements SaveLoadManager {
     this.commandGroupSystem.update(dT);
     this.autoGroupMonitor.update(dT);
     this.dynamics.moveObjects(dT);
-    this.updateClouds(dT); // Оновлюємо систему хмар
-    this.updateEnvironment(); // Оновлюємо environment ефекти (полярне сяйво)
+    this.environment.update(dT);
     const currentTime = performance.now();
     if (currentTime - this.lastExplosionTime >= this.explosionInterval) {
       this.lastExplosionTime = currentTime;
@@ -694,33 +694,6 @@ export class MapLogic implements SaveLoadManager {
       createdAt: Date.now(),
     };
     this.commandSystem.addCommand(objectId, command);
-  }
-
-  private generateClouds() {
-    const cloudCount = 2;
-    for (let i = 0; i < cloudCount; i++) {
-      const x = (Math.random() - 0.5) * 150;
-      const z = (Math.random() - 0.5) * 150;
-      const cloud: TSceneObject = {
-        id: `dust_cloud_${i}`,
-        type: 'cloud',
-        coordinates: { x, y: 0, z },
-        scale: { x: 1, y: 1, z: 1 },
-        rotation: { x: 0, y: 0, z: 0 },
-        speed: { x: (Math.random() - 0.5) * 1.5, y: 0, z: (Math.random() - 0.5) * 1.5 },
-        data: {
-          size: 21 + Math.random() * 22,
-          color: 0xd2b46c,
-          particleCount: 200,
-          windSpeed: 0.3 + Math.random() * 0.7,
-          height: 4 + Math.random() * 8,
-        },
-        tags: ['on-ground', 'dust', 'dynamic'],
-        bottomAnchor: -1,
-        terrainAlign: false,
-      };
-      this.scene.pushObjectWithTerrainConstraint(cloud);
-    }
   }
 
   /** Mining / Charging **/
@@ -821,105 +794,4 @@ export class MapLogic implements SaveLoadManager {
   /**
    * Генерує нову хмару на карті
    */
-  private generateDynamicCloud(): void {
-    const cloudId = `dynamic_cloud_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    const createdAt = Date.now();
-    const ttl = 60000; // 60 секунд TTL
-
-    // Генеруємо випадкові координати в межах карти
-    const mapWidth = MAP_CONFIG.width;
-    const mapDepth = MAP_CONFIG.depth;
-    const x = (Math.random() - 0.5) * mapWidth;
-    const z = (Math.random() - 0.5) * mapDepth;
-
-    // Створюємо об'єкт хмари
-    const cloud: TSceneObject = {
-      id: cloudId,
-      type: 'cloud',
-      coordinates: { x, y: 0, z },
-      scale: { x: 1, y: 1, z: 1 },
-      rotation: { x: 0, y: 0, z: 0 },
-      speed: { 
-        x: (Math.random() - 0.5) * 1.5, 
-        y: 0, 
-        z: (Math.random() - 0.5) * 1.5 
-      },
-      data: {
-        size: 21 + Math.random() * 22,
-        color: 0xd2b46c,
-        particleCount: 200,
-        windSpeed: 0.3 + Math.random() * 0.7,
-        height: 4 + Math.random() * 8,
-        createdAt: createdAt,
-        ttl: ttl,
-        fadeStartTime: 45000 // Початок згасання за 15 секунд до завершення
-      },
-      tags: ['on-ground', 'dust', 'dynamic'],
-      bottomAnchor: -1,
-      terrainAlign: false,
-    };
-
-    // Додаємо хмару до сцени
-    this.scene.pushObjectWithTerrainConstraint(cloud);
-    
-    // Записуємо в активні хмари для відстеження TTL
-    this.activeClouds.set(cloudId, { createdAt, ttl });
-
-    console.log(`Generated dynamic cloud ${cloudId} at (${x.toFixed(1)}, ${z.toFixed(1)})`);
-  }
-
-  /**
-   * Оновлює стан всіх активних хмар (TTL та згасання)
-   */
-  private updateClouds(deltaTime: number): void {
-    const now = Date.now();
-    const cloudsToRemove: string[] = [];
-
-    // Оновлюємо таймер генерації
-    this.cloudGenerationTimer += deltaTime;
-    if (this.cloudGenerationTimer >= this.cloudGenerationInterval) {
-      this.generateDynamicCloud();
-      this.cloudGenerationTimer = 0;
-    }
-
-    // Перевіряємо всі активні хмари
-    for (const [cloudId, cloudData] of this.activeClouds) {
-      const age = now - cloudData.createdAt;
-      
-      // Якщо час життя закінчився - видаляємо хмару
-      if (age >= cloudData.ttl) {
-        this.scene.removeObject(cloudId);
-        cloudsToRemove.push(cloudId);
-        continue;
-      }
-
-      // Якщо почався період згасання - зменшуємо прозорість
-      const fadeStartTime = 45000; // 15 секунд до завершення
-      if (age >= fadeStartTime) {
-        const fadeProgress = (age - fadeStartTime) / (cloudData.ttl - fadeStartTime);
-        const opacity = Math.max(0, 1 - fadeProgress);
-        
-        // Оновлюємо прозорість хмари
-        const cloud = this.scene.getObjectById(cloudId);
-        if (cloud && cloud.data && cloud.data.color) {
-          const alpha = Math.floor(opacity * 255);
-          cloud.data.color = (cloud.data.color & 0xFFFFFF) | (alpha << 24);
-        }
-      }
-    }
-
-    // Видаляємо хмари що закінчили життя
-    for (const cloudId of cloudsToRemove) {
-      this.activeClouds.delete(cloudId);
-    }
-  }
-
-  /**
-   * Оновлює environment ефекти (полярне сяйво, погода тощо)
-   */
-  public updateEnvironment(): void {
-    if (this.environment) {
-      this.environment.update();
-    }
-  }
 }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -9,11 +9,12 @@ export * from './screens/colony';
 export { Modal } from './shared/Modal';
 export { Button } from './shared/Button';
 export { MainMenu } from './screens/menu';
-export { 
-  ResourcesBar, 
-  CommandPanel, 
-  Scene3D, 
-  CameraController, 
+export {
+  ResourcesBar,
+  CommandPanel,
+  GlobalTimeDisplay,
+  Scene3D,
+  CameraController,
   AreaSelectionRenderer,
   UpgradesPanel, 
   UpgradesModal 

--- a/src/ui/screens/colony/index.ts
+++ b/src/ui/screens/colony/index.ts
@@ -1,5 +1,5 @@
 // UI Controls
-export { ResourcesBar, CommandPanel, SegmentedConstructionPanel } from './ui-controls';
+export { ResourcesBar, CommandPanel, SegmentedConstructionPanel, GlobalTimeDisplay } from './ui-controls';
 
 // Scene
 export { Scene3D, CameraController, AreaSelectionRenderer } from './scene';

--- a/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
+++ b/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
@@ -83,6 +83,21 @@ export function useRenderLoop(
       tryCall('aurora', 'updateEnvironmentEffects');
     }
 
+    const lights = (scene as THREE.Scene & {
+      __lights__?: { ambient: THREE.AmbientLight; dir: THREE.DirectionalLight };
+    }).__lights__;
+    const environment: any = mapLogicRef.current && (mapLogicRef.current as any).environment;
+    if (lights && environment?.getSunLightState) {
+      const sunState = environment.getSunLightState();
+      lights.dir.intensity = sunState.directionalIntensity;
+      lights.dir.position.set(
+        sunState.direction.x,
+        sunState.direction.y,
+        sunState.direction.z,
+      );
+      lights.ambient.intensity = sunState.ambientIntensity;
+    }
+
     options.syncVisibleObjects();
 
     if (areaSelectionRendererRef.current) {

--- a/src/ui/screens/colony/scene/renderers/BuildingPreview.ts
+++ b/src/ui/screens/colony/scene/renderers/BuildingPreview.ts
@@ -65,8 +65,7 @@ export class BuildingPreview {
         this.loadedModels.set(modelPath, gltf.scene);
         this.showLoadedModel(position, buildingData, gltf.scene);
       },
-      (progress) => {
-      },
+      undefined,
       (error) => {
         console.error('BuildingPreview: Error loading model:', error);
         // Fallback до простої геометрії

--- a/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/GlobalTimeDisplay.css
+++ b/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/GlobalTimeDisplay.css
@@ -1,0 +1,43 @@
+.global-time {
+  position: fixed;
+  top: 108px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  text-align: center;
+  z-index: 900;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.global-time__time {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.global-time__weather {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  font-size: 13px;
+  opacity: 0.9;
+}
+
+@media (max-width: 1280px) {
+  .global-time {
+    top: 120px;
+    padding: 6px 12px;
+  }
+
+  .global-time__weather {
+    flex-direction: column;
+    gap: 6px;
+  }
+}

--- a/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/GlobalTimeDisplay.tsx
+++ b/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/GlobalTimeDisplay.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import type { EnvironmentState } from '@systems/environment/environment.types';
+import { EnvironmentLogic } from '@systems/environment/EnvironmentLogic';
+import './GlobalTimeDisplay.css';
+
+interface GlobalTimeDisplayProps {
+  environment?: EnvironmentLogic;
+}
+
+const formatTemperature = (value: number): string => {
+  const rounded = Math.round(value);
+  const prefix = rounded > 0 ? '+' : '';
+  return `${prefix}${rounded}°C`;
+};
+
+const formatWind = (value: number): string => {
+  return `${Math.round(value)} м/с`;
+};
+
+export const GlobalTimeDisplay: React.FC<GlobalTimeDisplayProps> = ({ environment }) => {
+  const [state, setState] = useState<EnvironmentState | null>(() =>
+    environment ? environment.getEnvironmentState() : null,
+  );
+
+  useEffect(() => {
+    if (!environment) {
+      setState(null);
+      return;
+    }
+
+    const update = () => {
+      setState(environment.getEnvironmentState());
+    };
+
+    update();
+    const intervalId = window.setInterval(update, 500);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [environment]);
+
+  if (!environment || !state) {
+    return null;
+  }
+
+  return (
+    <div className="box global-time">
+      <div className="global-time__time">
+        День {state.day} • {state.time.formatted}
+      </div>
+      <div className="global-time__weather">
+        <span>Температура: {formatTemperature(state.temperature)}</span>
+        <span>Вітер: {formatWind(state.windSpeed)}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/index.ts
+++ b/src/ui/screens/colony/ui-controls/GlobalTimeDisplay/index.ts
@@ -1,0 +1,1 @@
+export { GlobalTimeDisplay } from './GlobalTimeDisplay';

--- a/src/ui/screens/colony/ui-controls/index.ts
+++ b/src/ui/screens/colony/ui-controls/index.ts
@@ -1,3 +1,4 @@
 export { ResourcesBar } from './ResourcesBar';
 export { CommandPanel } from './CommandPanel';
 export { SegmentedConstructionPanel } from './SegmentedConstructionPanel';
+export { GlobalTimeDisplay } from './GlobalTimeDisplay';


### PR DESCRIPTION
## Summary
- expand the environment system to track day/night time, weather, and dust clouds with MAP_CONFIG-driven settings
- drive scene lighting based on the simulated sun position and expose environment state through a new global time display component
- clean up build warnings by removing unused helpers and wiring the new HUD into the app shell

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1aa4dada88320a4deddc8df3be1b0