### PR TITLE
Smooth sun descent and hide disc below horizon

### DIFF
--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -709,7 +709,23 @@ export class EnvironmentLogic {
         : altitudeAboveHorizon > 0
         ? 1
         : 0;
-    const discOpacity = this.clamp(intensity, 0, 1) * horizonFade;
+
+    const belowHorizon = Math.abs(Math.min(0, altitudeDeg));
+    const fadeStartBelow = Math.max(2.5, horizonFadeDeg * 0.5);
+    const fadeEndBelow = fadeStartBelow + Math.max(2.5, horizonFadeDeg * 0.6);
+    let discVisibility = 1;
+    if (belowHorizon > 0) {
+      if (belowHorizon >= fadeEndBelow) {
+        discVisibility = 0;
+      } else if (belowHorizon > fadeStartBelow) {
+        const fadeT = (belowHorizon - fadeStartBelow) / Math.max(0.0001, fadeEndBelow - fadeStartBelow);
+        discVisibility = Math.pow(1 - fadeT, 1.15);
+      }
+    }
+
+    const directionalBrightness = this.clamp(intensity, 0, 1);
+    const discBaseLuminance = 0.6 + directionalBrightness * 0.4;
+    const discOpacity = this.clamp(discBaseLuminance * discVisibility, 0, 1);
     const haloIntensity = this.clamp(
       haloBaseIntensity * Math.max(horizonFade, Math.pow(horizonWeight, 0.6)),
       0,

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -2,10 +2,13 @@ import { SceneLogic } from '@scene/scene-logic';
 import { TSceneObject } from '@scene/scene.types';
 import {
   AuroraEffect,
+  ColorRGB,
   EnvironmentConfig,
+  EnvironmentSaveData,
   EnvironmentState,
   IEnvironmentEffect,
   SunLightState,
+  SunVisualConfig,
 } from './environment.types';
 
 /**
@@ -56,6 +59,23 @@ const DEFAULT_CONFIG: EnvironmentConfig = {
     windSpeed: { min: 0.3, max: 1.0 },
     particleCount: 200,
     color: 0xd2b46c,
+  },
+  sun: {
+    altitudeRangeDeg: { min: 6, max: 45 },
+    azimuthOffsetDeg: -10,
+    orbitRadiusMultiplier: 0.6,
+    orbitFlattening: 0.45,
+    discSize: 42,
+    haloSize: 140,
+    haloIntensity: { day: 0.55, horizon: 0.85, night: 0 },
+    colorShiftExponent: 1.6,
+    haloFalloffExponent: 1.4,
+    colors: {
+      base: 0xfff1c2,
+      sunrise: 0xffc08a,
+      sunset: 0xff7b63,
+      halo: 0xffd8a1,
+    },
   },
 };
 
@@ -198,6 +218,67 @@ export class EnvironmentLogic {
   }
 
   /**
+   * Отримати поточні налаштування вигляду сонця
+   */
+  getSunVisualConfig(): SunVisualConfig {
+    return {
+      ...this.config.sun,
+      altitudeRangeDeg: { ...this.config.sun.altitudeRangeDeg },
+      haloIntensity: { ...this.config.sun.haloIntensity },
+      colors: { ...this.config.sun.colors },
+    };
+  }
+
+  /**
+   * Оновити налаштування вигляду сонця
+   */
+  updateSunVisualConfig(update: Partial<SunVisualConfig>): void {
+    this.config.sun = this.mergeSunConfig(this.config.sun, update);
+    this.state = this.buildEnvironmentState();
+  }
+
+  /**
+   * Дані для збереження стану енвайронменту
+   */
+  getSaveData(): EnvironmentSaveData {
+    return {
+      time: { totalMinutes: this.time.totalMinutes },
+      weather: {
+        windSpeed: this.weather.windSpeed,
+        windTarget: this.weather.windTarget,
+        nextWindChangeMinute: this.weather.nextWindChangeMinute,
+      },
+    };
+  }
+
+  /**
+   * Відновити стан енвайронменту з сейву
+   */
+  loadFromSave(data: EnvironmentSaveData | undefined): void {
+    if (!data) return;
+
+    if (typeof data.time?.totalMinutes === 'number' && !Number.isNaN(data.time.totalMinutes)) {
+      this.time.totalMinutes = data.time.totalMinutes;
+      this.updateTimeFromTotalMinutes();
+    }
+
+    if (data.weather) {
+      if (typeof data.weather.windSpeed === 'number') {
+        this.weather.windSpeed = data.weather.windSpeed;
+      }
+      if (typeof data.weather.windTarget === 'number') {
+        this.weather.windTarget = data.weather.windTarget;
+      }
+      if (typeof data.weather.nextWindChangeMinute === 'number') {
+        this.weather.nextWindChangeMinute = data.weather.nextWindChangeMinute;
+      }
+    }
+
+    this.weather.temperature = this.calculateTemperature();
+    this.state = this.buildEnvironmentState();
+  }
+
+  /**
    * Встановити час доби (0.0 = північ, 0.5 = полудень, 1.0 = північ)
    */
   setTimeOfDay(timeOfDay: number): void {
@@ -284,9 +365,38 @@ export class EnvironmentLogic {
           ...(overrides.dustClouds?.windSpeed ?? {}),
         },
       },
+      sun: this.mergeSunConfig(base.sun, overrides.sun),
     };
 
     return merged;
+  }
+
+  private mergeSunConfig(base: SunVisualConfig, overrides?: Partial<SunVisualConfig>): SunVisualConfig {
+    if (!overrides) {
+      return {
+        ...base,
+        altitudeRangeDeg: { ...base.altitudeRangeDeg },
+        haloIntensity: { ...base.haloIntensity },
+        colors: { ...base.colors },
+      };
+    }
+
+    return {
+      ...base,
+      ...overrides,
+      altitudeRangeDeg: {
+        ...base.altitudeRangeDeg,
+        ...(overrides.altitudeRangeDeg ?? {}),
+      },
+      haloIntensity: {
+        ...base.haloIntensity,
+        ...(overrides.haloIntensity ?? {}),
+      },
+      colors: {
+        ...base.colors,
+        ...(overrides.colors ?? {}),
+      },
+    };
   }
 
   private advanceTime(deltaTimeSeconds: number): void {
@@ -501,6 +611,7 @@ export class EnvironmentLogic {
 
   private calculateSunLightState(): SunLightState {
     const { sunriseHour, sunsetHour, twilightDurationHours } = this.config.time;
+    const sunCfg = this.config.sun;
     const sunriseMinutes = sunriseHour * 60;
     const sunsetMinutes = sunsetHour * 60;
     const twilightMinutes = twilightDurationHours * 60;
@@ -511,14 +622,14 @@ export class EnvironmentLogic {
     let intensity = 0;
     if (minutes >= dawnStart && minutes < sunriseMinutes) {
       const t = (minutes - dawnStart) / Math.max(1, sunriseMinutes - dawnStart);
-      intensity = this.easeInOut(t) * 0.5;
+      intensity = this.easeInOut(t) * 0.55;
     } else if (minutes >= sunriseMinutes && minutes <= sunsetMinutes) {
       const dayRange = Math.max(1, sunsetMinutes - sunriseMinutes);
       const t = (minutes - sunriseMinutes) / dayRange;
-      intensity = 0.5 + Math.sin(t * Math.PI) * 0.5;
+      intensity = 0.55 + Math.sin(t * Math.PI) * 0.45;
     } else if (minutes > sunsetMinutes && minutes < duskEnd) {
       const t = (duskEnd - minutes) / Math.max(1, duskEnd - sunsetMinutes);
-      intensity = this.easeInOut(t) * 0.5;
+      intensity = this.easeInOut(t) * 0.55;
     } else {
       intensity = 0;
     }
@@ -526,19 +637,96 @@ export class EnvironmentLogic {
     intensity = this.clamp(intensity, 0, 1);
     const ambientIntensity = 0.18 + intensity * 0.35;
 
-    const fullProgress = this.time.currentMinutes / 1440;
-    const orbitAngle = (fullProgress - 0.25) * 2 * Math.PI;
-    const radius = Math.max(this.config.mapSize.width, this.config.mapSize.depth) * 0.6;
-    const direction = {
-      x: Math.cos(orbitAngle) * radius,
-      y: Math.max(30, Math.sin(orbitAngle) * radius * 0.8),
-      z: Math.sin(orbitAngle * 0.5) * radius * 0.4,
-    };
+    const dayMinutes = 1440;
+    const fullProgress = (this.time.totalMinutes % dayMinutes) / dayMinutes;
+    const orbitOffset = (sunCfg.azimuthOffsetDeg / 360) * 2 * Math.PI;
+    const orbitAngle = (fullProgress - 0.25) * 2 * Math.PI + orbitOffset;
+    const rawElevation = Math.sin(orbitAngle);
+    const easedElevation = Math.sign(rawElevation) * Math.pow(Math.abs(rawElevation), 0.92);
+
+    const maxAltitudeDeg = Math.max(0, sunCfg.altitudeRangeDeg.max);
+    const altitudeRad = (easedElevation * maxAltitudeDeg * Math.PI) / 180;
+    const altitudeDeg = (altitudeRad * 180) / Math.PI;
+    const baseRadius = Math.max(this.config.mapSize.width, this.config.mapSize.depth) * sunCfg.orbitRadiusMultiplier;
+    const horizontalRadius = Math.cos(altitudeRad) * baseRadius;
+    const y = Math.sin(altitudeRad) * baseRadius;
+    const x = Math.cos(orbitAngle) * horizontalRadius;
+    const z = Math.sin(orbitAngle) * horizontalRadius * sunCfg.orbitFlattening;
+
+    const sunriseWeight = Math.pow(
+      this.clamp(1 - Math.abs(minutes - sunriseMinutes) / Math.max(1, twilightMinutes), 0, 1),
+      sunCfg.colorShiftExponent
+    );
+    const sunsetWeight = Math.pow(
+      this.clamp(1 - Math.abs(minutes - sunsetMinutes) / Math.max(1, twilightMinutes), 0, 1),
+      sunCfg.colorShiftExponent
+    );
+    const horizonWeight = Math.max(sunriseWeight, sunsetWeight);
+
+    const baseColor = this.hexToRgb(sunCfg.colors.base);
+    const sunriseColor = this.hexToRgb(sunCfg.colors.sunrise);
+    const sunsetColor = this.hexToRgb(sunCfg.colors.sunset);
+    const haloBase = this.hexToRgb(sunCfg.colors.halo);
+
+    let sunColor = { ...baseColor };
+    if (sunriseWeight > 0) {
+      sunColor = this.lerpColor(sunColor, sunriseColor, sunriseWeight);
+    }
+    if (sunsetWeight > 0) {
+      sunColor = this.lerpColor(sunColor, sunsetColor, sunsetWeight);
+    }
+
+    let haloColor = { ...haloBase };
+    if (sunriseWeight > 0) {
+      haloColor = this.lerpColor(haloColor, sunriseColor, sunriseWeight * 0.6);
+    }
+    if (sunsetWeight > 0) {
+      haloColor = this.lerpColor(haloColor, sunsetColor, sunsetWeight * 0.6);
+    }
+
+    const white = { r: 1, g: 1, b: 1 };
+    const directionalColor = this.lerpColor(sunColor, white, 0.1 + horizonWeight * 0.2);
+
+    const haloDay = this.lerp(
+      sunCfg.haloIntensity.day,
+      sunCfg.haloIntensity.horizon,
+      Math.pow(horizonWeight, sunCfg.haloFalloffExponent)
+    );
+    const haloBaseIntensity = this.lerp(
+      sunCfg.haloIntensity.night,
+      haloDay,
+      Math.max(intensity, horizonWeight)
+    );
+
+    const discSize = sunCfg.discSize * (1 + horizonWeight * 0.2);
+    const haloSize = sunCfg.haloSize * (1 + horizonWeight * 0.35);
+
+    const horizonFadeDeg = Math.max(0, sunCfg.altitudeRangeDeg.min);
+    const altitudeAboveHorizon = Math.max(0, altitudeDeg);
+    const horizonFade =
+      horizonFadeDeg > 0
+        ? Math.pow(this.clamp(altitudeAboveHorizon / horizonFadeDeg, 0, 1), 0.85)
+        : altitudeAboveHorizon > 0
+        ? 1
+        : 0;
+    const discOpacity = this.clamp(intensity, 0, 1) * horizonFade;
+    const haloIntensity = this.clamp(
+      haloBaseIntensity * Math.max(horizonFade, Math.pow(horizonWeight, 0.6)),
+      0,
+      1
+    );
 
     return {
-      direction,
+      direction: { x, y, z },
       directionalIntensity: intensity,
       ambientIntensity,
+      directionalColor,
+      sunColor,
+      haloColor,
+      haloIntensity,
+      haloSize,
+      discSize,
+      discOpacity,
     };
   }
 
@@ -549,6 +737,29 @@ export class EnvironmentLogic {
 
   private clamp(value: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, value));
+  }
+
+  private lerp(a: number, b: number, t: number): number {
+    const clamped = this.clamp(t, 0, 1);
+    return a + (b - a) * clamped;
+  }
+
+  private lerpColor(a: ColorRGB, b: ColorRGB, t: number): ColorRGB {
+    const clamped = this.clamp(t, 0, 1);
+    return {
+      r: a.r + (b.r - a.r) * clamped,
+      g: a.g + (b.g - a.g) * clamped,
+      b: a.b + (b.b - a.b) * clamped,
+    };
+  }
+
+  private hexToRgb(hex: number): ColorRGB {
+    const value = Math.round(hex) & 0xffffff;
+    return {
+      r: ((value >> 16) & 0xff) / 255,
+      g: ((value >> 8) & 0xff) / 255,
+      b: (value & 0xff) / 255,
+    };
   }
 
   private randomBetween(min: number, max: number): number {

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -700,6 +700,9 @@ export class EnvironmentLogic {
 
     const horizonFadeDeg = Math.max(0, sunCfg.altitudeRangeDeg.min);
     const altitudeAboveHorizon = Math.max(0, altitudeDeg);
+    const nearHorizonRangeDeg = Math.max(1, horizonFadeDeg * 1.5);
+    const nearHorizon = this.clamp(1 - altitudeAboveHorizon / nearHorizonRangeDeg, 0, 1);
+    const horizonInfluence = Math.max(horizonWeight, Math.pow(nearHorizon, 0.85));
     const horizonFade =
       horizonFadeDeg > 0
         ? Math.pow(this.clamp(altitudeAboveHorizon / horizonFadeDeg, 0, 1), 0.85)
@@ -717,11 +720,12 @@ export class EnvironmentLogic {
       haloColor = this.lerpColor(haloColor, dominantWarmColor, warmBlend * 0.7);
     }
 
-    const discScaleBoost = 1 + horizonWeight * 0.35 + Math.pow(belowRatio, 0.7) * 0.25;
+    const discScaleBoost = 1 + horizonInfluence * 0.5 + Math.pow(belowRatio, 0.75) * 0.35;
     const discSize = sunCfg.discSize * discScaleBoost;
 
-    const haloScaleFactor = this.clamp(1 - Math.max(horizonWeight, belowRatio) * 0.45, 0.45, 1);
-    const haloSize = sunCfg.haloSize * haloScaleFactor;
+    const haloShrinkInfluence = Math.max(horizonInfluence, Math.pow(belowRatio, 0.8));
+    const haloSizeMultiplier = this.lerp(1, 0.42, haloShrinkInfluence);
+    const haloSize = sunCfg.haloSize * haloSizeMultiplier;
 
     const fadeStartBelow = maxVisibleDropDeg;
     const fadeEndBelow = fadeStartBelow + Math.max(2, horizonFadeDeg * 0.5);
@@ -741,7 +745,10 @@ export class EnvironmentLogic {
     const discOpacity = this.clamp(discBaseLuminance * discVisibility, 0, 1);
     const haloVisibilityFalloff = this.clamp(1 - (Math.pow(horizonWeight, 0.9) * 0.45 + belowRatio * 0.35), 0.2, 1);
     const haloIntensity = this.clamp(
-      haloBaseIntensity * Math.max(horizonFade, Math.pow(horizonWeight, 0.6)) * haloVisibilityFalloff,
+      haloBaseIntensity *
+        Math.max(horizonFade, Math.pow(horizonWeight, 0.6)) *
+        haloVisibilityFalloff *
+        Math.pow(haloSizeMultiplier, 0.8),
       0,
       1
     );

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -698,9 +698,6 @@ export class EnvironmentLogic {
       Math.max(intensity, horizonWeight)
     );
 
-    const discSize = sunCfg.discSize * (1 + horizonWeight * 0.2);
-    const haloSize = sunCfg.haloSize * (1 + horizonWeight * 0.35);
-
     const horizonFadeDeg = Math.max(0, sunCfg.altitudeRangeDeg.min);
     const altitudeAboveHorizon = Math.max(0, altitudeDeg);
     const horizonFade =
@@ -711,23 +708,40 @@ export class EnvironmentLogic {
         : 0;
 
     const belowHorizon = Math.abs(Math.min(0, altitudeDeg));
-    const fadeStartBelow = Math.max(2.5, horizonFadeDeg * 0.5);
-    const fadeEndBelow = fadeStartBelow + Math.max(2.5, horizonFadeDeg * 0.6);
+    const maxVisibleDropDeg = 5;
+    const belowRatio = this.clamp(belowHorizon / maxVisibleDropDeg, 0, 1);
+    if (belowHorizon > 0) {
+      const dominantWarmColor = sunriseWeight >= sunsetWeight ? sunriseColor : sunsetColor;
+      const warmBlend = Math.pow(belowRatio, 0.8);
+      sunColor = this.lerpColor(sunColor, dominantWarmColor, warmBlend);
+      haloColor = this.lerpColor(haloColor, dominantWarmColor, warmBlend * 0.7);
+    }
+
+    const discScaleBoost = 1 + horizonWeight * 0.35 + Math.pow(belowRatio, 0.7) * 0.25;
+    const discSize = sunCfg.discSize * discScaleBoost;
+
+    const haloScaleFactor = this.clamp(1 - Math.max(horizonWeight, belowRatio) * 0.45, 0.45, 1);
+    const haloSize = sunCfg.haloSize * haloScaleFactor;
+
+    const fadeStartBelow = maxVisibleDropDeg;
+    const fadeEndBelow = fadeStartBelow + Math.max(2, horizonFadeDeg * 0.5);
     let discVisibility = 1;
     if (belowHorizon > 0) {
       if (belowHorizon >= fadeEndBelow) {
         discVisibility = 0;
       } else if (belowHorizon > fadeStartBelow) {
         const fadeT = (belowHorizon - fadeStartBelow) / Math.max(0.0001, fadeEndBelow - fadeStartBelow);
-        discVisibility = Math.pow(1 - fadeT, 1.15);
+        discVisibility = Math.pow(1 - fadeT, 1.1);
       }
     }
 
     const directionalBrightness = this.clamp(intensity, 0, 1);
-    const discBaseLuminance = 0.6 + directionalBrightness * 0.4;
+    const glowPresence = Math.max(horizonWeight, Math.pow(belowRatio, 0.75));
+    const discBaseLuminance = 0.7 + Math.max(directionalBrightness, glowPresence) * 0.3;
     const discOpacity = this.clamp(discBaseLuminance * discVisibility, 0, 1);
+    const haloVisibilityFalloff = this.clamp(1 - (Math.pow(horizonWeight, 0.9) * 0.45 + belowRatio * 0.35), 0.2, 1);
     const haloIntensity = this.clamp(
-      haloBaseIntensity * Math.max(horizonFade, Math.pow(horizonWeight, 0.6)),
+      haloBaseIntensity * Math.max(horizonFade, Math.pow(horizonWeight, 0.6)) * haloVisibilityFalloff,
       0,
       1
     );

--- a/src/logic/systems/environment/environment.types.ts
+++ b/src/logic/systems/environment/environment.types.ts
@@ -81,10 +81,23 @@ export interface MapSizeConfig {
   depth: number;
 }
 
+export interface ColorRGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
 export interface SunLightState {
   direction: Vector3;
   directionalIntensity: number;
   ambientIntensity: number;
+  directionalColor: ColorRGB;
+  sunColor: ColorRGB;
+  haloColor: ColorRGB;
+  haloIntensity: number;
+  haloSize: number;
+  discSize: number;
+  discOpacity: number;
 }
 
 export interface EnvironmentState {
@@ -99,6 +112,35 @@ export interface EnvironmentState {
   windSpeed: number;
   isNight: boolean;
   sun: SunLightState;
+}
+
+export interface SunColorConfig {
+  base: number;
+  sunrise: number;
+  sunset: number;
+  halo: number;
+}
+
+export interface SunVisualConfig {
+  altitudeRangeDeg: { min: number; max: number };
+  azimuthOffsetDeg: number;
+  orbitRadiusMultiplier: number;
+  orbitFlattening: number;
+  discSize: number;
+  haloSize: number;
+  haloIntensity: { day: number; horizon: number; night: number };
+  colorShiftExponent: number;
+  haloFalloffExponent: number;
+  colors: SunColorConfig;
+}
+
+export interface EnvironmentSaveData {
+  time: { totalMinutes: number };
+  weather?: {
+    windSpeed: number;
+    windTarget: number;
+    nextWindChangeMinute: number;
+  };
 }
 
 /**
@@ -130,4 +172,7 @@ export interface EnvironmentConfig {
 
   // Параметри хмар з пилу
   dustClouds: DustCloudConfig;
+
+  // Параметри вигляду сонця
+  sun: SunVisualConfig;
 }

--- a/src/logic/systems/environment/index.ts
+++ b/src/logic/systems/environment/index.ts
@@ -3,6 +3,10 @@ export type {
   IEnvironmentEffect,
   AuroraEffect,
   EnvironmentConfig,
+  EnvironmentSaveData,
   EnvironmentState,
-  SunLightState
+  SunLightState,
+  SunVisualConfig,
+  SunColorConfig,
+  ColorRGB
 } from "./environment.types";

--- a/src/logic/systems/map/map-config.ts
+++ b/src/logic/systems/map/map-config.ts
@@ -118,6 +118,23 @@ export const MAP_CONFIG = {
             windSpeed: { min: 0.3, max: 1.0 },
             particleCount: 200,
             color: 0xd2b46c,
+        },
+        sun: {
+            altitudeRangeDeg: { min: 6, max: 45 },
+            azimuthOffsetDeg: -10,
+            orbitRadiusMultiplier: 0.6,
+            orbitFlattening: 0.45,
+            discSize: 46,
+            haloSize: 155,
+            haloIntensity: { day: 0.55, horizon: 0.9, night: 0 },
+            colorShiftExponent: 1.6,
+            haloFalloffExponent: 1.4,
+            colors: {
+                base: 0xfff1d2,
+                sunrise: 0xffb27d,
+                sunset: 0xff6a57,
+                halo: 0xffd2a4,
+            },
         }
     }
 };

--- a/src/logic/systems/map/map-logic.ts
+++ b/src/logic/systems/map/map-logic.ts
@@ -732,13 +732,20 @@ export class MapLogic implements SaveLoadManager {
   // ==================== SaveLoadManager ====================
   save(): MapLogicSaveData {
     const collectedRocks: string[] = Array.from(this.collectedRocks);
-    return { seed: this.generatedSeed, collectedRocks };
+    return {
+      seed: this.generatedSeed,
+      collectedRocks,
+      environment: this.environment.getSaveData(),
+    };
   }
   load(data: MapLogicSaveData): void {
     if (data.seed) {
       this.generatedSeed = data.seed;
       this.generationTracker = new MapGenerationTracker(data.seed);
       this.initializeSeeded();
+    }
+    if (data.environment) {
+      this.environment.loadFromSave(data.environment);
     }
     if (data.collectedRocks) {
       let rockIds: string[];

--- a/src/logic/systems/save-load/save-load.types.ts
+++ b/src/logic/systems/save-load/save-load.types.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from '@utils/vector-math';
+import { EnvironmentSaveData } from '@systems/environment/environment.types';
 
 // Базовий інтерфейс для всіх менеджерів
 export interface SaveLoadManager {
@@ -39,6 +40,7 @@ export interface MapLogicSaveData {
     seed: number; // Seed для генерації карти
     collectedRocks: string[] | Set<string> | Record<string, string>; // ID зібраних каменюків (різні типи для сумісності)
     // buildingPositions тепер зберігаються в BuildingsManager
+    environment?: EnvironmentSaveData;
 }
 
 // Дані командної системи

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -15,6 +15,7 @@ import { UiLogicBridge } from '@ui/logic/UiLogicBridge'
 import { SmokeRenderer } from './SmokeRenderer'
 import { RoadRenderer } from './RoadRenderer'
 import { AuroraRenderer } from './environment/AuroraRenderer'
+import { SunRenderer } from './environment/SunRenderer'
 // import { ExplosionRenderer } from './ExplosionRenderer'
 
 export class RendererManager {
@@ -64,6 +65,7 @@ export class RendererManager {
         this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Хмари
         this.registerRenderer('smoke', new SmokeRenderer(this.scene, this.renderer)); // Дим (GPU)
         this.registerRenderer('fire', new FireRenderer(this.scene, this.renderer)); // Вогонь (GPU)
+        this.registerRenderer('sun', new SunRenderer(this.scene));
         const roadRenderer = new RoadRenderer(this.scene, this.renderer);
         if (this.bridge && (roadRenderer as any).setUiLogicBridge) {
             (roadRenderer as any).setUiLogicBridge(this.bridge as any);

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
@@ -1,0 +1,122 @@
+import * as THREE from 'three';
+import { BaseRenderer } from '../BaseRenderer';
+import { TSceneObject } from '@logic/systems/scene/scene.types';
+import { SunLightState } from '@logic/systems/environment/environment.types';
+
+export class SunRenderer extends BaseRenderer {
+  private sunGroup: THREE.Group;
+  private disc: THREE.Sprite;
+  private halo: THREE.Sprite;
+  private discTexture: THREE.Texture;
+  private haloTexture: THREE.Texture;
+
+  constructor(scene: THREE.Scene) {
+    super(scene);
+
+    this.discTexture = this.createRadialTexture(0.45, 0.05);
+    this.haloTexture = this.createRadialTexture(0.12, 0.0);
+
+    this.sunGroup = new THREE.Group();
+    this.sunGroup.name = 'SunVisual';
+    this.sunGroup.renderOrder = 9999;
+
+    const haloMaterial = new THREE.SpriteMaterial({
+      map: this.haloTexture,
+      color: new THREE.Color(1, 0.9, 0.7),
+      transparent: true,
+      opacity: 0,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+
+    this.halo = new THREE.Sprite(haloMaterial);
+    this.halo.renderOrder = 9998;
+    this.sunGroup.add(this.halo);
+
+    const discMaterial = new THREE.SpriteMaterial({
+      map: this.discTexture,
+      color: new THREE.Color(1, 1, 1),
+      transparent: true,
+      opacity: 0,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+
+    this.disc = new THREE.Sprite(discMaterial);
+    this.disc.renderOrder = 10000;
+    this.sunGroup.add(this.disc);
+
+    this.scene.add(this.sunGroup);
+  }
+
+  render(_object: TSceneObject): THREE.Object3D {
+    return new THREE.Group();
+  }
+
+  update(_object: TSceneObject): void {}
+  remove(_id: string): void {}
+  getMeshById(_id: string): THREE.Object3D | null { return null; }
+
+  updateSunState(state: SunLightState): void {
+    const position = new THREE.Vector3(state.direction.x, state.direction.y, state.direction.z);
+    const renderPosition = position.clone();
+    if (renderPosition.y < 0) {
+      renderPosition.y = 0;
+    }
+    this.sunGroup.position.copy(renderPosition);
+
+    const discMaterial = this.disc.material as THREE.SpriteMaterial;
+    discMaterial.color.setRGB(state.sunColor.r, state.sunColor.g, state.sunColor.b);
+    const discOpacity = THREE.MathUtils.clamp(state.discOpacity, 0, 1);
+    discMaterial.opacity = discOpacity;
+
+    const haloMaterial = this.halo.material as THREE.SpriteMaterial;
+    haloMaterial.color.setRGB(state.haloColor.r, state.haloColor.g, state.haloColor.b);
+    const haloOpacity = THREE.MathUtils.clamp(state.haloIntensity, 0, 1);
+    haloMaterial.opacity = haloOpacity;
+
+    this.disc.scale.setScalar(state.discSize);
+    this.halo.scale.setScalar(state.haloSize);
+
+    this.sunGroup.visible = discOpacity > 0.01 || haloOpacity > 0.01;
+  }
+
+  dispose(): void {
+    super.dispose();
+    this.scene.remove(this.sunGroup);
+    this.discTexture.dispose();
+    this.haloTexture.dispose();
+    (this.disc.material as THREE.Material).dispose();
+    (this.halo.material as THREE.Material).dispose();
+  }
+
+  private createRadialTexture(coreStop: number, outerOpacity: number): THREE.Texture {
+    const size = 256;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('SunRenderer: cannot acquire 2D context');
+    }
+
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+    gradient.addColorStop(0, 'rgba(255,255,255,1)');
+    gradient.addColorStop(coreStop, `rgba(255,255,255,${outerOpacity})`);
+    gradient.addColorStop(1, 'rgba(255,255,255,0)');
+
+    ctx.clearRect(0, 0, size, size);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearMipMapLinearFilter;
+    texture.generateMipmaps = true;
+    texture.needsUpdate = true;
+    return texture;
+  }
+}

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
@@ -25,7 +25,7 @@ export class SunRenderer extends BaseRenderer {
       color: new THREE.Color(1, 0.9, 0.7),
       transparent: true,
       opacity: 0,
-      depthTest: false,
+      depthTest: true,
       depthWrite: false,
       blending: THREE.AdditiveBlending,
     });
@@ -39,7 +39,7 @@ export class SunRenderer extends BaseRenderer {
       color: new THREE.Color(1, 1, 1),
       transparent: true,
       opacity: 0,
-      depthTest: false,
+      depthTest: true,
       depthWrite: false,
       blending: THREE.AdditiveBlending,
     });

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/SunRenderer.ts
@@ -62,9 +62,23 @@ export class SunRenderer extends BaseRenderer {
   updateSunState(state: SunLightState): void {
     const position = new THREE.Vector3(state.direction.x, state.direction.y, state.direction.z);
     const renderPosition = position.clone();
-    if (renderPosition.y < 0) {
-      renderPosition.y = 0;
+
+    const radius = renderPosition.length();
+    if (radius > 0) {
+      const horizontal = Math.sqrt(renderPosition.x * renderPosition.x + renderPosition.z * renderPosition.z);
+      const altitude = Math.atan2(renderPosition.y, horizontal);
+      const minAltitude = THREE.MathUtils.degToRad(-5);
+      if (altitude < minAltitude) {
+        const azimuth = Math.atan2(renderPosition.z, renderPosition.x);
+        const clampedHorizontal = Math.cos(minAltitude) * radius;
+        renderPosition.set(
+          Math.cos(azimuth) * clampedHorizontal,
+          Math.sin(minAltitude) * radius,
+          Math.sin(azimuth) * clampedHorizontal,
+        );
+      }
     }
+
     this.sunGroup.position.copy(renderPosition);
 
     const discMaterial = this.disc.material as THREE.SpriteMaterial;

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/index.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/index.ts
@@ -1,1 +1,2 @@
 export { AuroraRenderer } from "./AuroraRenderer";
+export { SunRenderer } from "./SunRenderer";

--- a/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
+++ b/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
@@ -95,7 +95,22 @@ export function useRenderLoop(
         sunState.direction.y,
         sunState.direction.z,
       );
+      lights.dir.color.setRGB(
+        sunState.directionalColor.r,
+        sunState.directionalColor.g,
+        sunState.directionalColor.b,
+      );
       lights.ambient.intensity = sunState.ambientIntensity;
+      lights.ambient.color.setRGB(
+        sunState.haloColor.r,
+        sunState.haloColor.g,
+        sunState.haloColor.b,
+      );
+
+      const sunRenderer = rendererManagerRef.current?.renderers.get('sun') as
+        | { updateSunState?: (state: typeof sunState) => void }
+        | undefined;
+      sunRenderer?.updateSunState?.(sunState);
     }
 
     options.syncVisibleObjects();

--- a/src/ui/screens/colony/scene/interaction/InteractionManager.ts
+++ b/src/ui/screens/colony/scene/interaction/InteractionManager.ts
@@ -27,10 +27,21 @@ export class InteractionManager {
     document.addEventListener('contextmenu', this.handleContextMenu);
   }
 
+  private isUiTarget(target: HTMLElement | null): boolean {
+    if (!target) return false;
+    return Boolean(
+      target.closest('.command-panel') ||
+      target.closest('.buildings-panel') ||
+      target.closest('.ui-panel') ||
+      target.closest('button') ||
+      target.closest('input')
+    );
+  }
+
   private readonly handleMouseDown = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
-    if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
+    if (this.isUiTarget(target)) {
       return; // Ігноруємо події над UI елементами
     }
 
@@ -50,8 +61,8 @@ export class InteractionManager {
   private readonly handleMouseMove = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
-    if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
-      return; // Ігноруємо події над UI елементами
+    if (this.isUiTarget(target) && !this.isMouseDown) {
+      return; // Ігноруємо рухи, які почалися на UI
     }
 
     this.mousePosition = { x: event.clientX, y: event.clientY };
@@ -68,8 +79,8 @@ export class InteractionManager {
   private readonly handleMouseUp = (event: MouseEvent): void => {
     // Перевіряємо, чи подія відбувається над UI елементом
     const target = event.target as HTMLElement;
-    if (target && (target.closest('.command-panel') || target.closest('.buildings-panel') || target.closest('.ui-panel') || target.closest('button') || target.closest('input'))) {
-      return; // Ігноруємо події над UI елементами
+    if (this.isUiTarget(target) && !this.isMouseDown) {
+      return; // Ігноруємо завершення, яке не стосується сцени
     }
 
     this.isMouseDown = false;


### PR DESCRIPTION
## Summary
- smooth the sun's orbit so it crosses the horizon without snapping and compute a fade factor for disc visibility
- expose disc opacity in the sun light state while clamping halo intensity to horizon-driven visibility
- update the sun renderer to keep the twilight glow but stop drawing the disc once it drops below the horizon

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b483fd90832097f30ff2791e8e4a