### PR TITLE
Add graphics settings controls and renderer integration

### DIFF
--- a/public/icons/interface/settings.svg
+++ b/public/icons/interface/settings.svg
@@ -1,0 +1,10 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#F8FAFC" stroke-width="8" stroke-linecap="round" stroke-miterlimit="10">
+    <path d="M18 24H78" />
+    <path d="M18 48H78" />
+    <path d="M18 72H78" />
+  </g>
+  <circle cx="34" cy="24" r="11" fill="#60A5FA" />
+  <circle cx="60" cy="48" r="11" fill="#38BDF8" />
+  <circle cx="44" cy="72" r="11" fill="#A855F7" />
+</svg>

--- a/src/logic/core/game/GameContainer.ts
+++ b/src/logic/core/game/GameContainer.ts
@@ -14,7 +14,8 @@ export type ServiceKey =
   | 'mapLogic'
   | 'commandSystem'
   | 'commandGroupSystem'
-  | 'saveManager';
+  | 'saveManager'
+  | 'graphicsSettingsManager';
 
 // Мапа типів сервісів
 export interface ServiceTypeMap {
@@ -30,6 +31,7 @@ export interface ServiceTypeMap {
   commandSystem: import('../../interfaces/ICommandSystem').ICommandSystem;
   commandGroupSystem: import('../../interfaces/ICommandGroupSystem').ICommandGroupSystem;
   saveManager: import('../../interfaces/ISaveManager').ISaveManager;
+  graphicsSettingsManager: import('../../systems/graphics').GraphicsSettingsManager;
 }
 
 export class GameContainer {
@@ -115,7 +117,7 @@ export class GameContainer {
     const requiredServices: ServiceKey[] = [
       'sceneLogic', 'bonusSystem', 'dynamicsLogic', 'resourceManager',
       'upgradesManager', 'buildingsManager', 'droneManager', 'mapLogic',
-      'commandSystem', 'commandGroupSystem', 'saveManager'
+      'commandSystem', 'commandGroupSystem', 'saveManager', 'graphicsSettingsManager'
     ];
     
     const missing = requiredServices.filter(service => !this.has(service));

--- a/src/logic/core/game/GameServices.ts
+++ b/src/logic/core/game/GameServices.ts
@@ -1,5 +1,6 @@
 // Групуємо пов'язані сервіси разом
 import { ISceneLogic, IResourceManager, IBonusSystem, IBuildingsManager, IUpgradesManager, IDroneManager, ICommandSystem, ICommandGroupSystem, ISaveManager } from '../../interfaces/index';
+import type { GraphicsSettingsManager } from '@systems/graphics';
 import { DynamicsLogic } from '../../systems/scene/dynamics-logic';
 
 /**
@@ -38,12 +39,13 @@ export interface GameObjectServices {
 /**
  * Всі сервіси разом (поточний інтерфейс для сумісності)
  */
-export interface AllGameServices extends 
-  CoreServices, 
-  ResourceServices, 
-  CommandServices, 
+export interface AllGameServices extends
+  CoreServices,
+  ResourceServices,
+  CommandServices,
   GameObjectServices {
   saveManager: ISaveManager;
+  graphicsSettingsManager: GraphicsSettingsManager;
 }
 
 /**

--- a/src/logic/core/game/game.ts
+++ b/src/logic/core/game/game.ts
@@ -14,6 +14,7 @@ import { initEffects } from '@shared/effects';
 import { GameContainer } from './GameContainer';
 import { ISceneLogic, IResourceManager, IBonusSystem, IBuildingsManager, IUpgradesManager, IDroneManager, ISaveManager } from '../../interfaces/index';
 import { Logger } from '@shared/ErrorService';
+import { GraphicsSettingsManager } from '@systems/graphics';
 // Видалено невикористовувані імпорти для Result
 
 
@@ -28,6 +29,7 @@ export class Game {
   public readonly commandSystem: CommandSystem;  // Конкретний клас для сумісності
   public readonly commandGroupSystem: CommandGroupSystem;  // Конкретний клас для сумісності
   public readonly saveManager: ISaveManager;
+  public readonly graphicsSettings: GraphicsSettingsManager;
   
   // Система бонусів та модифікаторів
   public readonly bonusSystem: IBonusSystem;
@@ -111,6 +113,8 @@ export class Game {
     this.container.register('saveManager', () => new SaveManager(
       this.container.get('mapLogic') as any  // Тимчасовий cast
     ));
+
+    this.container.register('graphicsSettingsManager', () => new GraphicsSettingsManager());
   }
 
   private constructor() {
@@ -132,6 +136,7 @@ export class Game {
     this.commandSystem = this.container.get('commandSystem') as CommandSystem;
     this.commandGroupSystem = this.container.get('commandGroupSystem') as CommandGroupSystem;
     this.saveManager = this.container.get('saveManager');
+    this.graphicsSettings = this.container.get('graphicsSettingsManager');
 
     this.mapLogic.setCommandSystems(this.commandSystem, this.commandGroupSystem);
     
@@ -154,6 +159,7 @@ export class Game {
     this.saveManager.registerManager('commandGroupSystem', this.commandGroupSystem as any);
     this.saveManager.registerManager('upgradesManager', this.upgradesManager);
     this.saveManager.registerManager('buildingsManager', this.buildingsManager);
+    this.saveManager.registerManager('graphicsSettings', this.graphicsSettings);
 
     initEffects(this.bonusSystem)
     

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -689,29 +689,11 @@ export class EnvironmentLogic {
     const white = { r: 1, g: 1, b: 1 };
     const directionalColor = this.lerpColor(sunColor, white, 0.1 + horizonWeight * 0.2);
 
-    const haloDay = this.lerp(
-      sunCfg.haloIntensity.day,
-      sunCfg.haloIntensity.horizon,
-      Math.pow(horizonWeight, sunCfg.haloFalloffExponent)
-    );
-    const haloBaseIntensity = this.lerp(
-      sunCfg.haloIntensity.night,
-      haloDay,
-      Math.max(intensity, horizonWeight)
-    );
-
     const horizonFadeDeg = Math.max(0, sunCfg.altitudeRangeDeg.min);
     const altitudeAboveHorizon = Math.max(0, altitudeDeg);
     const nearHorizonRangeDeg = Math.max(1, horizonFadeDeg * 1.5);
     const nearHorizon = this.clamp(1 - altitudeAboveHorizon / nearHorizonRangeDeg, 0, 1);
     const horizonInfluence = Math.max(horizonWeight, Math.pow(nearHorizon, 0.85));
-    const horizonFade =
-      horizonFadeDeg > 0
-        ? Math.pow(this.clamp(altitudeAboveHorizon / horizonFadeDeg, 0, 1), 0.85)
-        : altitudeAboveHorizon > 0
-        ? 1
-        : 0;
-
     const belowHorizon = Math.abs(Math.min(0, altitudeDeg));
     const maxVisibleDropDeg = 5;
     const belowRatio = this.clamp(belowHorizon / maxVisibleDropDeg, 0, 1);
@@ -745,7 +727,6 @@ export class EnvironmentLogic {
     const glowPresence = Math.max(horizonWeight, Math.pow(belowRatio, 0.75));
     const discBaseLuminance = 0.7 + Math.max(directionalBrightness, glowPresence) * 0.3;
     const discOpacity = this.clamp(discBaseLuminance * discVisibility, 0, 1);
-    const haloVisibilityFalloff = this.clamp(1 - (Math.pow(horizonWeight, 0.9) * 0.45 + belowRatio * 0.35), 0.2, 1);
     const haloIntensity = 0; // Вимкнено для тесту
 
     // Колір фону в залежності від пори доби

--- a/src/logic/systems/graphics/GraphicsSettingsManager.ts
+++ b/src/logic/systems/graphics/GraphicsSettingsManager.ts
@@ -1,0 +1,99 @@
+import type { SaveLoadManager } from '@save-load/save-load.types';
+
+export type ShadowQuality = 'detailed' | 'pseudo' | 'none';
+export type ParticleQuality = 'high' | 'low';
+
+export interface GraphicsSettingsState {
+  shadows: ShadowQuality;
+  particles: ParticleQuality;
+}
+
+const DEFAULT_SETTINGS: GraphicsSettingsState = {
+  shadows: 'pseudo',
+  particles: 'high',
+};
+
+type Listener = (state: GraphicsSettingsState) => void;
+
+export class GraphicsSettingsManager implements SaveLoadManager {
+  private state: GraphicsSettingsState = { ...DEFAULT_SETTINGS };
+  private listeners = new Set<Listener>();
+
+  public getState(): GraphicsSettingsState {
+    return this.state;
+  }
+
+  public setShadowQuality(shadows: ShadowQuality): void {
+    if (this.state.shadows === shadows) return;
+    this.state = { ...this.state, shadows };
+    this.emit();
+  }
+
+  public setParticleQuality(particles: ParticleQuality): void {
+    if (this.state.particles === particles) return;
+    this.state = { ...this.state, particles };
+    this.emit();
+  }
+
+  public update(partial: Partial<GraphicsSettingsState>): void {
+    const next: GraphicsSettingsState = { ...this.state, ...partial };
+    if (next.shadows === this.state.shadows && next.particles === this.state.particles) {
+      return;
+    }
+    this.state = next;
+    this.emit();
+  }
+
+  public subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+
+  public save(): GraphicsSettingsState {
+    return { ...this.state };
+  }
+
+  public load(data: any): void {
+    if (!data || typeof data !== 'object') {
+      this.state = { ...DEFAULT_SETTINGS };
+      this.emit();
+      return;
+    }
+
+    const next: GraphicsSettingsState = {
+      shadows: this.parseShadowQuality((data as GraphicsSettingsState).shadows),
+      particles: this.parseParticleQuality((data as GraphicsSettingsState).particles),
+    };
+
+    this.state = next;
+    this.emit();
+  }
+
+  public reset(): void {
+    this.state = { ...DEFAULT_SETTINGS };
+    this.emit();
+  }
+
+  private parseShadowQuality(value: unknown): ShadowQuality {
+    if (value === 'detailed' || value === 'pseudo' || value === 'none') {
+      return value;
+    }
+    return DEFAULT_SETTINGS.shadows;
+  }
+
+  private parseParticleQuality(value: unknown): ParticleQuality {
+    if (value === 'high' || value === 'low') {
+      return value;
+    }
+    return DEFAULT_SETTINGS.particles;
+  }
+}

--- a/src/logic/systems/graphics/index.ts
+++ b/src/logic/systems/graphics/index.ts
@@ -1,0 +1,2 @@
+export { GraphicsSettingsManager } from './GraphicsSettingsManager';
+export type { GraphicsSettingsState, ParticleQuality, ShadowQuality } from './GraphicsSettingsManager';

--- a/src/logic/systems/save-load/save-load.types.ts
+++ b/src/logic/systems/save-load/save-load.types.ts
@@ -1,5 +1,6 @@
 import { Vector3 } from '@utils/vector-math';
 import { EnvironmentSaveData } from '@systems/environment/environment.types';
+import type { GraphicsSettingsState } from '@systems/graphics';
 
 // Базовий інтерфейс для всіх менеджерів
 export interface SaveLoadManager {
@@ -13,7 +14,7 @@ export interface GameSave {
     slot: number;
     timestamp: number;
     version: string;
-    
+
     // Дані менеджерів
     resourceManager: ResourceSaveData;
     mapLogic: MapLogicSaveData;
@@ -22,6 +23,7 @@ export interface GameSave {
     droneManager: DroneSaveData;
     upgradesManager: UpgradesManagerSaveData;
     buildingsManager: BuildingsManagerSaveData;
+    graphicsSettings: GraphicsSettingsState;
 }
 
 // Дані ресурсів
@@ -121,4 +123,12 @@ export interface BuildingsManagerSaveData {
 }
 
 // Тип для даних менеджера
-export type SaveData = ResourceSaveData | MapLogicSaveData | CommandSystemSaveData | CommandGroupSystemSaveData | DroneSaveData | UpgradesManagerSaveData | BuildingsManagerSaveData;
+export type SaveData =
+  | ResourceSaveData
+  | MapLogicSaveData
+  | CommandSystemSaveData
+  | CommandGroupSystemSaveData
+  | DroneSaveData
+  | UpgradesManagerSaveData
+  | BuildingsManagerSaveData
+  | GraphicsSettingsState;

--- a/src/logic/systems/save-load/save-manager.ts
+++ b/src/logic/systems/save-load/save-manager.ts
@@ -52,6 +52,7 @@ export class SaveManager implements SaveLoadManager, ISaveManager {
                 droneManager: this.managers.get('droneManager')?.save() as any,
                 upgradesManager: this.managers.get('upgradesManager')?.save() as any,
                 buildingsManager: this.managers.get('buildingsManager')?.save() as any,
+                graphicsSettings: this.managers.get('graphicsSettings')?.save() as any,
             };
             
             // Зберігаємо в localStorage
@@ -158,7 +159,16 @@ export class SaveManager implements SaveLoadManager, ISaveManager {
     }
 
     public getLoadOrder(): string[] {
-        return ['mapLogic', 'resourceManager', 'droneManager', 'upgradesManager', 'buildingsManager', 'commandGroupSystem', 'commandSystem'];
+        return [
+            'mapLogic',
+            'resourceManager',
+            'droneManager',
+            'upgradesManager',
+            'buildingsManager',
+            'graphicsSettings',
+            'commandGroupSystem',
+            'commandSystem'
+        ];
     }
 
     // ==================== SaveLoadManager Implementation ====================

--- a/src/ui/screens/colony/index.ts
+++ b/src/ui/screens/colony/index.ts
@@ -9,3 +9,6 @@ export { UpgradesPanel, UpgradesModal } from './upgrades';
 
 // Buildings
 export { BuildingsPanel, BuildingsModal } from './buildings';
+
+// Settings
+export { GraphicsSettingsModal, useGraphicsSettingsMenuButton } from './settings';

--- a/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
+++ b/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
@@ -40,6 +40,7 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
   const loadingManager = loadingManagerRef.current;
   const loadingSnapshot = useSceneLoadingSnapshot(loadingManager);
   const [isSceneReady, setIsSceneReady] = useState(false);
+  const [graphicsSettingsState, setGraphicsSettingsState] = useState(game.graphicsSettings.getState());
   const manualPending = Math.max(0, loadingSnapshot.manualTotal - loadingSnapshot.manualCompleted);
   const loadingMessage = loadingSnapshot.lastUrl
     ? `Завантаження: ${loadingSnapshot.lastUrl.split('/').pop()}`
@@ -54,7 +55,7 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
     areaSelectionRendererRef,
     mapLogicRef,
     managersReady,
-  } = useSceneManagers(scene, camera, renderer, appMapLogic, loadingManager);
+  } = useSceneManagers(scene, camera, renderer, appMapLogic, loadingManager, game.graphicsSettings);
 
   const { buildingPreviewRef, isReady: buildingPreviewReady } = useBuildingPreview(
     scene,
@@ -118,6 +119,33 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
       setIsSceneReady(true);
     }
   }, [isSceneReady, managersReady, buildingPreviewReady, loadingManager, loadingSnapshot]);
+
+  useEffect(() => {
+    return game.graphicsSettings.subscribe(setGraphicsSettingsState);
+  }, [game]);
+
+  useEffect(() => {
+    if (!managersReady) return;
+    const shadows = graphicsSettingsState.shadows;
+    const enableDetailed = shadows === 'detailed';
+    renderer.shadowMap.enabled = enableDetailed;
+    if (enableDetailed) {
+      renderer.shadowMap.needsUpdate = true;
+    }
+    const lights = (scene as THREE.Scene & {
+      __lights__?: { ambient: THREE.AmbientLight; dir: THREE.DirectionalLight };
+    }).__lights__;
+    if (lights?.dir) {
+      lights.dir.castShadow = enableDetailed;
+    }
+    rendererManagerRef.current?.setShadowMode(shadows);
+    terrainRendererRef.current?.setShadowMode(shadows);
+  }, [graphicsSettingsState.shadows, renderer, scene, rendererManagerRef, terrainRendererRef, managersReady]);
+
+  useEffect(() => {
+    if (!managersReady) return;
+    rendererManagerRef.current?.setParticleQuality(graphicsSettingsState.particles);
+  }, [graphicsSettingsState.particles, rendererManagerRef, managersReady]);
 
   useEffect(() => {
     const map = mapLogicRef.current;

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BiomassRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BiomassRenderer.ts
@@ -3,6 +3,8 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { BaseRenderer } from './BaseRenderer'
 import { TSceneObject } from '@logic/systems/scene/scene.types'
 import { MapLogic } from '@logic/systems/map/map-logic'
+import { applyBakedShadow, removeBakedShadow } from './utils/bakedShadows'
+import type { ShadowQuality } from '@systems/graphics'
 
 interface BiomassData {
   resourceId?: string;
@@ -16,6 +18,8 @@ interface BiomassInstance {
   mesh: THREE.Object3D;
 }
 
+type ShadowOptions = { intensity?: number; softness?: number; minSize?: number; offset?: number };
+
 export class BiomassRenderer extends BaseRenderer {
   private loader: GLTFLoader;
   
@@ -27,11 +31,89 @@ export class BiomassRenderer extends BaseRenderer {
   
   // Фоллбеки, що чекають заміни
   private pendingFallbacks: Map<string, { mesh: THREE.Mesh; object: TSceneObject }> = new Map();
-  
+
   private modelsReady = false;
-  
+
   // Моделі біомаси - використовуємо централізований список з MapLogic
   private readonly BIOMASS_MODELS = MapLogic.BIOMASS_MODELS;
+
+  private readonly shadowBox = new THREE.Box3();
+  private readonly shadowSize = new THREE.Vector3();
+  private readonly shadowCenter = new THREE.Vector3();
+
+  private shadowMode: ShadowQuality = 'pseudo';
+  private shadowConfigs = new Map<string, ShadowOptions>();
+
+  private computeShadowFootprint(source: THREE.Object3D) {
+    source.updateWorldMatrix(true, true)
+    this.shadowBox.setFromObject(source)
+    this.shadowBox.getSize(this.shadowSize)
+    this.shadowCenter.set(0, 0, 0)
+    this.shadowBox.getCenter(this.shadowCenter)
+
+    return {
+      width: this.shadowSize.x,
+      depth: this.shadowSize.z,
+      minY: this.shadowBox.min.y,
+      centerX: this.shadowCenter.x,
+      centerZ: this.shadowCenter.z,
+    }
+  }
+
+  private applyShadow(
+    instanceId: string,
+    target: THREE.Object3D,
+    footprint: { width: number; depth: number; minY: number; centerX: number; centerZ: number },
+    options?: ShadowOptions
+  ) {
+    this.shadowConfigs.set(instanceId, options ?? {});
+
+    const enableDynamic = this.shadowMode === 'detailed';
+    this.setShadowFlags(target, enableDynamic);
+    removeBakedShadow(target);
+
+    if (!enableDynamic && this.shadowMode === 'pseudo') {
+      applyBakedShadow(target, {
+        width: footprint.width,
+        depth: footprint.depth,
+        minY: footprint.minY,
+        centerX: footprint.centerX,
+        centerZ: footprint.centerZ,
+        intensity: options?.intensity ?? 0.4,
+        softness: options?.softness ?? 1.3,
+        minSize: options?.minSize ?? 0.35,
+        offset: options?.offset,
+      });
+    }
+  }
+
+  private setShadowFlags(target: THREE.Object3D, enabled: boolean) {
+    target.traverse((child) => {
+      if ((child as any).userData?.bakedShadow) return;
+      if (child instanceof THREE.Mesh) {
+        child.castShadow = enabled;
+        child.receiveShadow = enabled;
+      }
+    });
+  }
+
+  public setShadowMode(mode: ShadowQuality): void {
+    this.shadowMode = mode;
+
+    for (const instance of this.instances.values()) {
+      removeBakedShadow(instance.mesh);
+      const footprint = this.computeShadowFootprint(instance.mesh);
+      const options = this.shadowConfigs.get(instance.id);
+      this.applyShadow(instance.id, instance.mesh, footprint, options);
+    }
+
+    for (const [id, { mesh }] of this.pendingFallbacks) {
+      removeBakedShadow(mesh);
+      const footprint = this.computeShadowFootprint(mesh);
+      const options = this.shadowConfigs.get(id);
+      this.applyShadow(id, mesh, footprint, options);
+    }
+  }
 
   constructor(scene: THREE.Scene) {
     super(scene);
@@ -53,8 +135,8 @@ export class BiomassRenderer extends BaseRenderer {
           // Оптимізуємо модель
           clonedScene.traverse((child) => {
             if (child instanceof THREE.Mesh) {
-              child.castShadow = true;
-              child.receiveShadow = true;
+              child.castShadow = false;
+              child.receiveShadow = false;
             }
           });
           
@@ -127,9 +209,20 @@ export class BiomassRenderer extends BaseRenderer {
     // Клонуємо модель з кешу
     const cachedModel = this.modelCache.get(modelPath)!;
     const mesh = cachedModel.clone();
-    
+
+    mesh.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.castShadow = false;
+        child.receiveShadow = false;
+      }
+    });
+
+    const footprint = this.computeShadowFootprint(mesh);
+
     // Налаштовуємо позицію, масштаб та обертання
     this.setupMeshTransform(mesh, object);
+
+    this.applyShadow(object.id, mesh, footprint, { intensity: 0.45, softness: 1.25, minSize: 0.35 });
     
     // Додаємо до сцени
     this.addMesh(object.id, mesh);
@@ -162,7 +255,9 @@ export class BiomassRenderer extends BaseRenderer {
       this.scene.remove(instance.mesh);
       this.instances.delete(id);
     }
-    
+
+    this.shadowConfigs.delete(id);
+
     // Видаляємо з базового рендерера
     super.remove(id);
     
@@ -180,6 +275,10 @@ export class BiomassRenderer extends BaseRenderer {
 
   private updateInstance(instance: BiomassInstance): void {
     this.setupMeshTransform(instance.mesh, instance.object);
+    removeBakedShadow(instance.mesh);
+    const footprint = this.computeShadowFootprint(instance.mesh);
+    const options = this.shadowConfigs.get(instance.id);
+    this.applyShadow(instance.id, instance.mesh, footprint, options);
   }
 
   private setupMeshTransform(mesh: THREE.Object3D, object: TSceneObject): void {
@@ -207,12 +306,16 @@ export class BiomassRenderer extends BaseRenderer {
     });
     
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+
+    const footprint = this.computeShadowFootprint(mesh);
+
     // Налаштовуємо позицію
     this.setupMeshTransform(mesh, object);
-    
+
+    this.applyShadow(object.id, mesh, footprint, { intensity: 0.38, softness: 1.3, minSize: 0.3 });
+
     return mesh;
   }
 

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -9,6 +9,8 @@ import { ResourceRequest } from '@logic/modules/resources/resource-types';
 import { HudCanvasBuilder, BUILDING_HUD_STYLE } from './hud/HudCanvasBuilder';
 import type { HudCanvasRequest, HudResourceEntry } from './hud/HudCanvasBuilder';
 import { clampScaleByWidth, computeScreenSpaceScale } from './hud/hudMath';
+import { applyBakedShadow, removeBakedShadow } from './utils/bakedShadows';
+import type { ShadowQuality } from '@systems/graphics';
 
 // ---------- TMP ----------
 const _qCam = new THREE.Quaternion();
@@ -16,6 +18,9 @@ const _worldScale = new THREE.Vector3();
 const _worldPos = new THREE.Vector3();
 const _localOffset = new THREE.Vector3();
 const _viewDir = new THREE.Vector3();
+const _shadowSize = new THREE.Vector3();
+const _shadowCenter = new THREE.Vector3();
+const _shadowBox = new THREE.Box3();
 
 // ---------- Screen-space таргети ----------
 // Позиціонування у світі
@@ -30,6 +35,8 @@ type ResourceInfo = {
   progress: number;
 };
 
+type ShadowOptions = { intensity?: number; softness?: number; minSize?: number; offset?: number };
+
 export class BuildingRenderer extends BaseRenderer {
   private geometry: THREE.BoxGeometry;
   private material: THREE.MeshBasicMaterial;
@@ -37,8 +44,11 @@ export class BuildingRenderer extends BaseRenderer {
   private modelCache: Map<string, THREE.Group> = new Map();
   private readonly hudStyle = BUILDING_HUD_STYLE;
   private readonly hudBuilder: HudCanvasBuilder;
-  
+
   private uiLogicBridge: UiLogicBridge | null = null; // Bridge to logic for storage info
+
+  private shadowMode: ShadowQuality = 'pseudo';
+  private shadowSources = new WeakMap<THREE.Object3D, { source: THREE.Object3D; options?: ShadowOptions }>();
 
   constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer, loadingManager?: THREE.LoadingManager) {
     super(scene, renderer);
@@ -56,6 +66,95 @@ export class BuildingRenderer extends BaseRenderer {
 
     this.loader = new GLTFLoader(loadingManager ?? undefined);
     this.hudBuilder = new HudCanvasBuilder(renderer, this.hudStyle);
+  }
+
+  private applyShadowFromSource(
+    container: THREE.Object3D,
+    source: THREE.Object3D,
+    options?: ShadowOptions
+  ): void {
+    source.updateWorldMatrix(true, true);
+    _shadowBox.setFromObject(source);
+    _shadowBox.getSize(_shadowSize);
+    _shadowBox.getCenter(_shadowCenter);
+
+    applyBakedShadow(container, {
+      width: _shadowSize.x,
+      depth: _shadowSize.z,
+      minY: _shadowBox.min.y,
+      centerX: _shadowCenter.x,
+      centerZ: _shadowCenter.z,
+      intensity: options?.intensity,
+      softness: options?.softness,
+      minSize: options?.minSize,
+      offset: options?.offset,
+    });
+  }
+
+  public setShadowMode(mode: ShadowQuality): void {
+    this.shadowMode = mode;
+    for (const container of this.meshes.values()) {
+      this.reapplyStoredShadow(container);
+    }
+  }
+
+  private reapplyStoredShadow(container: THREE.Object3D): void {
+    const stored = this.shadowSources.get(container);
+    if (stored) {
+      this.applyShadowPreset(container, stored.source, stored.options);
+      return;
+    }
+
+    const fallbackSource = this.findShadowSource(container);
+    if (fallbackSource) {
+      this.applyShadowPreset(container, fallbackSource, undefined);
+    } else {
+      this.setContainerShadowFlags(container, this.shadowMode === 'detailed');
+      removeBakedShadow(container);
+    }
+  }
+
+  private applyShadowPreset(container: THREE.Object3D, source: THREE.Object3D, options?: ShadowOptions): void {
+    this.shadowSources.set(container, { source, options });
+
+    const enableDynamic = this.shadowMode === 'detailed';
+    this.setContainerShadowFlags(container, enableDynamic);
+    removeBakedShadow(container);
+
+    if (!enableDynamic && this.shadowMode === 'pseudo') {
+      this.applyShadowFromSource(container, source, options);
+    }
+  }
+
+  private setContainerShadowFlags(container: THREE.Object3D, enabled: boolean): void {
+    this.forEachShadowMesh(container, (mesh) => {
+      mesh.castShadow = enabled;
+      mesh.receiveShadow = enabled;
+    });
+  }
+
+  private forEachShadowMesh(root: THREE.Object3D, handler: (mesh: THREE.Mesh) => void): void {
+    root.traverse((child) => {
+      if ((child as any).userData?.bakedShadow) return;
+      if (child.name === 'combinedHUD') return;
+      if ((child as THREE.Mesh).isMesh) {
+        handler(child as THREE.Mesh);
+      }
+    });
+  }
+
+  private findShadowSource(container: THREE.Object3D): THREE.Object3D | null {
+    const queue: THREE.Object3D[] = [...container.children];
+    while (queue.length > 0) {
+      const child = queue.shift()!;
+      if ((child as any).userData?.bakedShadow) continue;
+      if (child.name === 'combinedHUD') continue;
+      if ((child as THREE.Mesh).isMesh || child.children.length > 0) {
+        return child;
+      }
+      queue.push(...child.children);
+    }
+    return null;
   }
 
   /**
@@ -134,6 +233,7 @@ export class BuildingRenderer extends BaseRenderer {
     const fallback = this.createFallbackMesh();
     fallback.name = 'fallback';
     container.add(fallback);
+    this.applyShadowPreset(container, fallback, { intensity: 0.25, softness: 1.15, minSize: 0.6 });
 
     if (isUnderConstruction) {
       const resourceInfo = this.getBuildingResourceInfo(buildingType, data?.resourcesCollected || {});
@@ -182,8 +282,8 @@ export class BuildingRenderer extends BaseRenderer {
             child.material = child.material.clone();
           }
 
-          child.castShadow = true;
-          child.receiveShadow = true;
+          child.castShadow = false;
+          child.receiveShadow = false;
         }
       });
 
@@ -204,6 +304,9 @@ export class BuildingRenderer extends BaseRenderer {
         if (child.isMesh && child.material) this.sanitizePBR(child, isUnderConstruction);
       });
 
+      const shadowIntensity = isUnderConstruction ? 0.32 : 0.55;
+      const shadowSoftness = isUnderConstruction ? 1.1 : 1.35;
+      this.applyShadowPreset(container, model, { intensity: shadowIntensity, softness: shadowSoftness, minSize: 0.6 });
       container.add(model);
 
       if (isUnderConstruction) {
@@ -541,8 +644,8 @@ export class BuildingRenderer extends BaseRenderer {
     const material = this.material.clone();
     const mesh = new THREE.Mesh(this.geometry, material);
     mesh.position.set(0, 0, 0);
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
     return mesh;
   }
 

--- a/src/ui/screens/colony/scene/Scene3D/renderers/FireRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/FireRenderer.ts
@@ -3,14 +3,33 @@ import * as THREE from 'three';
 import { BaseRenderer } from './BaseRenderer';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
 import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer.js';
+import type { ParticleQuality } from '@systems/graphics';
 
 type Vec3 = { x:number; y:number; z:number };
 
+type FireEmitterParams = {
+  position: Vec3;
+  color?: number;
+  emitRate: number;
+  spreadR: number;
+  spreadY: number;
+  sizeMul: number;
+  spreadGrow: number;
+  riseHeight: number;
+  tongueBoost: number;
+  tongueSharpness: number;
+};
+
 export class FireRenderer extends BaseRenderer {
-  private readonly PARTICLES_W = 128;
-  private readonly PARTICLES_H = 128;
-  private readonly MAX_PARTICLES = this.PARTICLES_W * this.PARTICLES_H;
+  private particleResolution = 128;
+  private get PARTICLES_W(): number { return this.particleResolution; }
+  private get PARTICLES_H(): number { return this.particleResolution; }
+  private get MAX_PARTICLES(): number { return this.particleResolution * this.particleResolution; }
   private readonly MAX_EMITTERS = 64;
+  private quality: ParticleQuality = 'high';
+  private emitRateScale = 1;
+  private basePointSize = 16;
+  private emitterParams = new Map<string, FireEmitterParams>();
   // ліміти часу та бюджетів
   private readonly MAX_DT_SIM = 1/30;          // клем для фізики (uDelta), ~33мс
   private readonly MAX_DT_SPAWN = 1/30;        // клем для емісії
@@ -36,30 +55,30 @@ export class FireRenderer extends BaseRenderer {
   // emitColTex:   rgb + emitRate(=a)
   // emitPropTex:  spreadR(=x), spreadY(=y), sizeMul(=z), (вільно)
   // emitExtraTex: riseHeight(=x), spreadGrow(=y), tongueBoost(=z), tongueSharpness(=w)
-  private emitPosData: Float32Array;
-  private emitColData: Float32Array;
-  private emitPropData: Float32Array;
-  private emitExtraData: Float32Array;
+  private emitPosData!: Float32Array;
+  private emitColData!: Float32Array;
+  private emitPropData!: Float32Array;
+  private emitExtraData!: Float32Array;
 
-  private emitPosTex: THREE.DataTexture;
-  private emitColTex: THREE.DataTexture;
-  private emitPropTex: THREE.DataTexture;
-  private emitExtraTex: THREE.DataTexture;
+  private emitPosTex!: THREE.DataTexture;
+  private emitColTex!: THREE.DataTexture;
+  private emitPropTex!: THREE.DataTexture;
+  private emitExtraTex!: THREE.DataTexture;
 
   private emitterCount = 0;
-  private emitterActive: boolean[];
+  private emitterActive!: boolean[];
 
   // --- OPT#2: Spawn map у RGBA8 + "touched list" ---
   // R=emitterIndex(0..255), G=seed1(0..255), B=seed2(0..255), A=flag(0/255)
-  private spawnMapData8: Uint8Array;
-  private spawnMapTex: THREE.DataTexture;
+  private spawnMapData8!: Uint8Array;
+  private spawnMapTex!: THREE.DataTexture;
   private touched: number[] = []; // індекси пікселів, які змінювали минулого кадру
 
   // Прайм-черга (щоб не робити позачерговий compute)
   private primeQueue: Array<{ emitter: number; left: number }> = [];
   private readonly MAX_PRIME_PER_FRAME = 2048; // скільки прайм-спавнів відпрацьовуємо за один update
 
-  private emitAcc: Float32Array;
+  private emitAcc!: Float32Array;
   private spawnHead = 0;
 
   // Dirty-прапорці для емітерних текстур
@@ -75,7 +94,14 @@ export class FireRenderer extends BaseRenderer {
     this.group.name = 'FireGroup_MWE_FlameTongues';
     this.scene.add(this.group);
 
-    // --- Емітерні текстури ---
+    this.initEmitterTextures();
+    this.initGPU();
+    this.initRenderPoints();
+  }
+
+  private initEmitterTextures(): void {
+    this.disposeDataTextures();
+
     this.emitPosData = new Float32Array(this.MAX_EMITTERS * 4);
     this.emitPosTex = new THREE.DataTexture(
       this.emitPosData as BufferSource, this.MAX_EMITTERS, 1, THREE.RGBAFormat, THREE.FloatType
@@ -112,9 +138,6 @@ export class FireRenderer extends BaseRenderer {
     this.emitExtraTex.minFilter = THREE.NearestFilter;
     this.emitExtraTex.wrapS = this.emitExtraTex.wrapT = THREE.ClampToEdgeWrapping;
 
-    this.emitterActive = Array(this.MAX_EMITTERS).fill(false);
-
-    // --- Spawn map RGBA8 ---
     this.spawnMapData8 = new Uint8Array(this.MAX_PARTICLES * 4);
     this.spawnMapTex = new THREE.DataTexture(
       this.spawnMapData8 as BufferSource, this.PARTICLES_W, this.PARTICLES_H, THREE.RGBAFormat, THREE.UnsignedByteType
@@ -124,10 +147,95 @@ export class FireRenderer extends BaseRenderer {
     this.spawnMapTex.minFilter = THREE.NearestFilter;
     this.spawnMapTex.wrapS = this.spawnMapTex.wrapT = THREE.ClampToEdgeWrapping;
 
+    this.emitterActive = Array(this.MAX_EMITTERS).fill(false);
     this.emitAcc = new Float32Array(this.MAX_EMITTERS);
+    this.spawnHead = 0;
+    this.touched = [];
+    this.primeQueue = [];
+    this.clock = new THREE.Clock();
 
+    this.emitPosDirty = true;
+    this.emitColDirty = true;
+    this.emitPropDirty = true;
+    this.emitExtraDirty = true;
+  }
+
+  private disposeDataTextures(): void {
+    this.spawnMapTex?.dispose();
+    this.emitPosTex?.dispose();
+    this.emitColTex?.dispose();
+    this.emitPropTex?.dispose();
+    this.emitExtraTex?.dispose();
+  }
+
+  private recreateSimulation(): void {
+    const cachedEmitters = Array.from(this.emitterParams.entries());
+
+    this.points?.removeFromParent();
+    this.material?.dispose();
+    this.geometry?.dispose();
+
+    this.initEmitterTextures();
     this.initGPU();
     this.initRenderPoints();
+
+    this.emitterCount = 0;
+    this.spawnHead = 0;
+    this.touched.length = 0;
+
+    const indexMap = (this.points as any).__emitterIndexMap as Map<string, number>;
+    indexMap.clear();
+
+    for (const [id, params] of cachedEmitters) {
+      const idx = this.addEmitter(
+        params.position,
+        params.color,
+        params.emitRate,
+        params.spreadR,
+        params.spreadY,
+        params.sizeMul,
+        params.spreadGrow,
+        params.riseHeight,
+        params.tongueBoost,
+        params.tongueSharpness
+      );
+      indexMap.set(id, idx);
+    }
+
+    for (const key of this.meshes.keys()) {
+      this.meshes.set(key, this.points);
+    }
+
+    if (this.material?.uniforms?.uPointSize) {
+      this.material.uniforms.uPointSize.value = this.basePointSize;
+    }
+  }
+
+  private extractEmitterParams(object: TSceneObject): FireEmitterParams {
+    const data: any = object.data || {};
+    return {
+      position: { x: object.coordinates.x, y: object.coordinates.y, z: object.coordinates.z },
+      color: data.color,
+      emitRate: data.emitRate ?? 120,
+      spreadR: data.spreadRadius ?? 0.08,
+      spreadY: data.spreadY ?? 0.02,
+      sizeMul: (data.baseSize ?? 10.0) / 10.0,
+      spreadGrow: data.spreadGrow ?? 0.0,
+      riseHeight: data.riseHeight ?? data.rise ?? 1.4,
+      tongueBoost: data.tongueBoost ?? 0.8,
+      tongueSharpness: data.tongueSharpness ?? 2.0,
+    };
+  }
+
+  public setQuality(quality: ParticleQuality): void {
+    if (this.quality === quality) return;
+
+    this.quality = quality;
+    this.emitRateScale = quality === 'high' ? 1 : 0.25;
+    this.basePointSize = quality === 'high' ? 16 : 32;
+    this.particleResolution = quality === 'high' ? 128 : 64;
+
+    this.recreateSimulation();
   }
 
   // ---------- GPU (compute) ----------
@@ -301,7 +409,7 @@ export class FireRenderer extends BaseRenderer {
         uEmitColTex:  { value: this.emitColTex },  // rgb + emitRate(a)
         uEmitPropTex: { value: this.emitPropTex }, // sizeMul у z
         uPixelRatio:  { value: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) },
-        uPointSize:   { value: 16.0 },
+        uPointSize:   { value: this.basePointSize },
       },
     });
     (this.material as any).toneMapped = false;
@@ -512,7 +620,7 @@ export class FireRenderer extends BaseRenderer {
     }
 
     const c  = new THREE.Color(color ?? 0xffa040);
-    const r  = (emitRate ?? 120);
+    const r  = (emitRate ?? 120) * this.emitRateScale;
     const sr = (spreadR ?? 0.08);
     const sy = (spreadY ?? 0.02);
     const sm = (sizeMul ?? 1.2);
@@ -587,7 +695,7 @@ export class FireRenderer extends BaseRenderer {
         this.emitColData[o2+1] = c.g;
         this.emitColData[o2+2] = c.b;
       }
-      if (emitRate !== undefined) this.emitColData[o2+3] = emitRate;
+      if (emitRate !== undefined) this.emitColData[o2+3] = emitRate * this.emitRateScale;
       this.emitColDirty = true;
     }
 
@@ -619,19 +727,20 @@ export class FireRenderer extends BaseRenderer {
 
   // інтеграція з твоїм TSceneObject
   render(object: TSceneObject): THREE.Object3D {
-            // Emitter додано
+    const params = this.extractEmitterParams(object);
     const idx = this.addEmitter(
-      object.coordinates,
-      object.data?.color,
-      object.data?.emitRate,
-      object.data?.spreadRadius,
-      object.data?.spreadY ?? 0.02,
-      (object.data?.baseSize ?? 10.0) / 10.0,
-      object.data?.spreadGrow ?? 0.0,
-      (object.data?.riseHeight ?? object.data?.rise ?? 1.4),
-      object.data?.tongueBoost ?? 0.8,
-      object.data?.tongueSharpness ?? 2.0,
+      params.position,
+      params.color,
+      params.emitRate,
+      params.spreadR,
+      params.spreadY,
+      params.sizeMul,
+      params.spreadGrow,
+      params.riseHeight,
+      params.tongueBoost,
+      params.tongueSharpness,
     );
+    this.emitterParams.set(object.id, params);
     this.addMesh(object.id, this.points);
     (this.points as any).__emitterIndexMap = (this.points as any).__emitterIndexMap || new Map<string, number>();
     (this.points as any).__emitterIndexMap.set(object.id, idx);
@@ -642,19 +751,21 @@ export class FireRenderer extends BaseRenderer {
     const map: Map<string, number> = (this.points as any).__emitterIndexMap;
     const idx = map?.get(object.id);
     if (idx !== undefined && idx >= 0) {
+      const params = this.extractEmitterParams(object);
       this.moveEmitter(
         idx,
-        object.coordinates,
-        object.data?.color,
-        object.data?.emitRate,
-        object.data?.spreadRadius,
-        object.data?.spreadY,
-        (object.data?.baseSize !== undefined) ? (object.data.baseSize / 10.0) : undefined,
-        object.data?.spreadGrow,
-        (object.data?.riseHeight ?? object.data?.rise),
-        object.data?.tongueBoost,
-        object.data?.tongueSharpness,
+        params.position,
+        params.color,
+        params.emitRate,
+        params.spreadR,
+        params.spreadY,
+        params.sizeMul,
+        params.spreadGrow,
+        params.riseHeight,
+        params.tongueBoost,
+        params.tongueSharpness,
       );
+      this.emitterParams.set(object.id, params);
     }
   }
 
@@ -665,6 +776,8 @@ export class FireRenderer extends BaseRenderer {
       this.setEmitterActive(idx, false);
       map.delete(id);
     }
+
+    this.emitterParams.delete(id);
   }
 
   dispose(): void {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -18,11 +18,17 @@ import { AuroraRenderer } from './environment/AuroraRenderer'
 import { SunRenderer } from './environment/SunRenderer'
 // import { ExplosionRenderer } from './ExplosionRenderer'
 
+import type { GraphicsSettingsManager, ParticleQuality, ShadowQuality } from '@systems/graphics'
+
 export class RendererManager {
     public renderers: Map<string, BaseRenderer> = new Map();
     private scene: THREE.Scene;
     private renderer: THREE.WebGLRenderer;
     private bridge: UiLogicBridge | null = null;
+    private graphicsSettings: GraphicsSettingsManager | null = null;
+    private graphicsSettingsUnsubscribe: (() => void) | null = null;
+    private shadowMode: ShadowQuality | null = null;
+    private particleQuality: ParticleQuality | null = null;
 
     constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer, bridge?: UiLogicBridge, loadingManager?: THREE.LoadingManager) {
         this.scene = scene;
@@ -61,10 +67,21 @@ export class RendererManager {
         if (this.bridge && (buildingRenderer as any).setUiLogicBridge) {
             (buildingRenderer as any).setUiLogicBridge(this.bridge);
         }
+        if (this.shadowMode) {
+            (buildingRenderer as any).setShadowMode?.(this.shadowMode);
+        }
         this.registerRenderer('building', buildingRenderer); // Будівлі
         this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Хмари
-        this.registerRenderer('smoke', new SmokeRenderer(this.scene, this.renderer)); // Дим (GPU)
-        this.registerRenderer('fire', new FireRenderer(this.scene, this.renderer)); // Вогонь (GPU)
+        const smokeRenderer = new SmokeRenderer(this.scene, this.renderer);
+        if (this.particleQuality) {
+            smokeRenderer.setQuality(this.particleQuality);
+        }
+        this.registerRenderer('smoke', smokeRenderer); // Дим (GPU)
+        const fireRenderer = new FireRenderer(this.scene, this.renderer);
+        if (this.particleQuality) {
+            fireRenderer.setQuality(this.particleQuality);
+        }
+        this.registerRenderer('fire', fireRenderer); // Вогонь (GPU)
         this.registerRenderer('sun', new SunRenderer(this.scene));
         const roadRenderer = new RoadRenderer(this.scene, this.renderer);
         if (this.bridge && (roadRenderer as any).setUiLogicBridge) {
@@ -132,14 +149,44 @@ export class RendererManager {
     // Очищення ресурсів (важливо для HMR!)
     // -------------------------
     public dispose(): void {
+        this.graphicsSettingsUnsubscribe?.();
+        this.graphicsSettingsUnsubscribe = null;
+        this.graphicsSettings = null;
         // Очищаємо всі рендерери
         for (const renderer of this.renderers.values()) {
             if (renderer.dispose) {
                 renderer.dispose();
             }
         }
-        
+
         // Очищаємо Map
         this.renderers.clear();
+    }
+
+    public attachGraphicsSettings(manager: GraphicsSettingsManager): void {
+        if (this.graphicsSettings === manager) return;
+
+        this.graphicsSettingsUnsubscribe?.();
+        this.graphicsSettings = manager;
+        this.graphicsSettingsUnsubscribe = manager.subscribe((state) => {
+            this.setShadowMode(state.shadows);
+            this.setParticleQuality(state.particles);
+        });
+    }
+
+    public setShadowMode(mode: ShadowQuality): void {
+        this.shadowMode = mode;
+        const buildingRenderer = this.renderers.get('building') as any;
+        buildingRenderer?.setShadowMode?.(mode);
+        const biomassRenderer = this.renderers.get('biomass') as any;
+        biomassRenderer?.setShadowMode?.(mode);
+    }
+
+    public setParticleQuality(quality: ParticleQuality): void {
+        this.particleQuality = quality;
+        const smokeRenderer = this.renderers.get('smoke') as any;
+        smokeRenderer?.setQuality?.(quality);
+        const fireRenderer = this.renderers.get('fire') as any;
+        fireRenderer?.setQuality?.(quality);
     }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/SmokeRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/SmokeRenderer.ts
@@ -3,14 +3,33 @@ import * as THREE from 'three';
 import { BaseRenderer } from './BaseRenderer';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
 import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer.js';
+import type { ParticleQuality } from '@systems/graphics';
 
 type Vec3 = { x:number; y:number; z:number };
 
+type SmokeEmitterParams = {
+  position: Vec3;
+  color?: number;
+  emitRate?: number;
+  spreadR?: number;
+  spreadY?: number;
+  sizeMul?: number;
+  spreadGrow?: number;
+  riseHeight?: number;
+  alphaMul?: number;
+  alphaDiminish?: number;
+};
+
 export class SmokeRenderer extends BaseRenderer {
-  private readonly PARTICLES_W = 128;
-  private readonly PARTICLES_H = 128;
-  private readonly MAX_PARTICLES = this.PARTICLES_W * this.PARTICLES_H;
+  private particleResolution = 128;
+  private get PARTICLES_W(): number { return this.particleResolution; }
+  private get PARTICLES_H(): number { return this.particleResolution; }
+  private get MAX_PARTICLES(): number { return this.particleResolution * this.particleResolution; }
   private readonly MAX_EMITTERS = 64;
+  private quality: ParticleQuality = 'high';
+  private emitRateScale = 1;
+  private basePointSize = 10;
+  private emitterParams = new Map<string, SmokeEmitterParams>();
 
   // --- анти-сплеск/анти-борг для спавну та симуляції ---
   private readonly MAX_DT_SIM = 1/30;          // clamp для фізики (uDelta) ~33мс
@@ -37,18 +56,18 @@ export class SmokeRenderer extends BaseRenderer {
   // emitColTex:   rgb + emitRate(=a)
   // emitPropTex:  spreadR(=x), spreadY(=y), sizeMul(=z), alphaMul(=w)
   // emitExtraTex: riseHeight(=x), spreadGrow(=y), alphaDiminish(=z), pad(=w)
-  private emitPosData: Float32Array;
-  private emitColData: Float32Array;
-  private emitPropData: Float32Array;
-  private emitExtraData: Float32Array;
+  private emitPosData!: Float32Array;
+  private emitColData!: Float32Array;
+  private emitPropData!: Float32Array;
+  private emitExtraData!: Float32Array;
 
-  private emitPosTex: THREE.DataTexture;
-  private emitColTex: THREE.DataTexture;
-  private emitPropTex: THREE.DataTexture;
-  private emitExtraTex: THREE.DataTexture;
+  private emitPosTex!: THREE.DataTexture;
+  private emitColTex!: THREE.DataTexture;
+  private emitPropTex!: THREE.DataTexture;
+  private emitExtraTex!: THREE.DataTexture;
 
   private emitterCount = 0;
-  private emitterActive: boolean[];
+  private emitterActive!: boolean[];
 
   // --- Dirty flags для емітерних текстур ---
   private emitPosDirty = false;
@@ -58,11 +77,11 @@ export class SmokeRenderer extends BaseRenderer {
 
   // --- OPT#2: Spawn map у RGBA8 + "touched list" ---
   // Формат: (R=emitterIndex 0..255, G=seed1 0..255, B=seed2 0..255, A=flag 0/255)
-  private spawnMapData8: Uint8Array;
-  private spawnMapTex: THREE.DataTexture;
+  private spawnMapData8!: Uint8Array;
+  private spawnMapTex!: THREE.DataTexture;
   private touched: number[] = []; // індекси пікселів, які ми ставили в попередньому кадрі
 
-  private emitAcc: Float32Array;
+  private emitAcc!: Float32Array;
   private spawnHead = 0;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
@@ -72,12 +91,19 @@ export class SmokeRenderer extends BaseRenderer {
     this.group.name = 'SmokeGroup_MWE_EmitRateSpreadCone';
     this.scene.add(this.group);
 
-    // --- Емітерні текстури ---
+    this.initEmitterTextures();
+    this.initGPU();
+    this.initRenderPoints();
+  }
+
+  private initEmitterTextures(): void {
+    this.disposeDataTextures();
+
     this.emitPosData = new Float32Array(this.MAX_EMITTERS * 4);
     this.emitPosTex = new THREE.DataTexture(
       this.emitPosData as BufferSource, this.MAX_EMITTERS, 1, THREE.RGBAFormat, THREE.FloatType
     );
-    this.emitPosTex.needsUpdate = true; // перший аплоад
+    this.emitPosTex.needsUpdate = true;
     this.emitPosTex.magFilter = THREE.NearestFilter;
     this.emitPosTex.minFilter = THREE.NearestFilter;
     this.emitPosTex.wrapS = this.emitPosTex.wrapT = THREE.ClampToEdgeWrapping;
@@ -109,9 +135,6 @@ export class SmokeRenderer extends BaseRenderer {
     this.emitExtraTex.minFilter = THREE.NearestFilter;
     this.emitExtraTex.wrapS = this.emitExtraTex.wrapT = THREE.ClampToEdgeWrapping;
 
-    this.emitterActive = Array(this.MAX_EMITTERS).fill(false);
-
-    // --- OPT#2: Spawn map RGBA8 ---
     this.spawnMapData8 = new Uint8Array(this.MAX_PARTICLES * 4);
     this.spawnMapTex = new THREE.DataTexture(
       this.spawnMapData8 as BufferSource, this.PARTICLES_W, this.PARTICLES_H, THREE.RGBAFormat, THREE.UnsignedByteType
@@ -121,10 +144,94 @@ export class SmokeRenderer extends BaseRenderer {
     this.spawnMapTex.minFilter = THREE.NearestFilter;
     this.spawnMapTex.wrapS = this.spawnMapTex.wrapT = THREE.ClampToEdgeWrapping;
 
+    this.emitterActive = Array(this.MAX_EMITTERS).fill(false);
     this.emitAcc = new Float32Array(this.MAX_EMITTERS);
+    this.spawnHead = 0;
+    this.touched = [];
+    this.clock = new THREE.Clock();
 
+    this.emitPosDirty = true;
+    this.emitColDirty = true;
+    this.emitPropDirty = true;
+    this.emitExtraDirty = true;
+  }
+
+  private disposeDataTextures(): void {
+    this.spawnMapTex?.dispose();
+    this.emitPosTex?.dispose();
+    this.emitColTex?.dispose();
+    this.emitPropTex?.dispose();
+    this.emitExtraTex?.dispose();
+  }
+
+  private recreateSimulation(): void {
+    const cachedEmitters = Array.from(this.emitterParams.entries());
+
+    this.points?.removeFromParent();
+    this.material?.dispose();
+    this.geometry?.dispose();
+
+    this.initEmitterTextures();
     this.initGPU();
     this.initRenderPoints();
+
+    this.emitterCount = 0;
+    this.spawnHead = 0;
+    this.touched.length = 0;
+
+    const indexMap = (this.points as any).__emitterIndexMap as Map<string, number>;
+    indexMap.clear();
+
+    for (const [id, params] of cachedEmitters) {
+      const idx = this.addEmitter(
+        params.position,
+        params.color,
+        params.emitRate,
+        params.spreadR,
+        params.spreadY,
+        params.sizeMul,
+        params.spreadGrow,
+        params.riseHeight,
+        params.alphaMul,
+        params.alphaDiminish
+      );
+      indexMap.set(id, idx);
+    }
+
+    for (const key of this.meshes.keys()) {
+      this.meshes.set(key, this.points);
+    }
+
+    if (this.material?.uniforms?.uPointSize) {
+      this.material.uniforms.uPointSize.value = this.basePointSize;
+    }
+  }
+
+  private extractEmitterParams(object: TSceneObject): SmokeEmitterParams {
+    const data: any = object.data || {};
+    return {
+      position: { x: object.coordinates.x, y: object.coordinates.y, z: object.coordinates.z },
+      color: data.color,
+      emitRate: data.emitRate ?? 20,
+      spreadR: data.spreadRadius ?? 0.15,
+      spreadY: data.spreadY ?? 0.03,
+      sizeMul: (data.baseSize ?? 10.0) / 10.0,
+      spreadGrow: data.spreadGrow ?? 0.25,
+      riseHeight: data.riseHeight ?? data.rise ?? 2.0,
+      alphaMul: data.alphaMul ?? data.opacity ?? 1.0,
+      alphaDiminish: data.alphaDiminish ?? data.alphaFade ?? 0.0,
+    };
+  }
+
+  public setQuality(quality: ParticleQuality): void {
+    if (this.quality === quality) return;
+
+    this.quality = quality;
+    this.emitRateScale = quality === 'high' ? 1 : 0.25;
+    this.basePointSize = quality === 'high' ? 10 : 20;
+    this.particleResolution = quality === 'high' ? 128 : 64;
+
+    this.recreateSimulation();
   }
 
   // ---------- GPU (compute) ----------
@@ -297,7 +404,7 @@ export class SmokeRenderer extends BaseRenderer {
         uEmitPosTex:   { value: this.emitPosTex },   // для heightFrac
         uEmitExtraTex: { value: this.emitExtraTex }, // для riseHeight & alphaDiminish
         uPixelRatio:   { value: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) },
-        uPointSize:    { value: 10.0 },
+        uPointSize:    { value: this.basePointSize },
       },
     });
 
@@ -508,7 +615,7 @@ export class SmokeRenderer extends BaseRenderer {
     }
 
     const c  = new THREE.Color(color ?? 0xcccccc);
-    const r  = (emitRate ?? 20);
+    const r  = (emitRate ?? 20) * this.emitRateScale;
     const sr = (spreadR ?? 0.15);
     const sy = (spreadY ?? 0.03);
     const sm = (sizeMul ?? 1.0);
@@ -584,7 +691,7 @@ export class SmokeRenderer extends BaseRenderer {
         this.emitColData[o2+1] = c.g;
         this.emitColData[o2+2] = c.b;
       }
-      if (emitRate !== undefined) this.emitColData[o2+3] = emitRate;
+      if (emitRate !== undefined) this.emitColData[o2+3] = emitRate * this.emitRateScale;
       this.emitColDirty = true;
     }
 
@@ -616,19 +723,20 @@ export class SmokeRenderer extends BaseRenderer {
 
   // інтеграція з твоїм TSceneObject
   render(object: TSceneObject): THREE.Object3D {
-    const alpha = (object.data?.alphaMul ?? object.data?.opacity ?? 1.0);
+    const params = this.extractEmitterParams(object);
     const idx = this.addEmitter(
-      object.coordinates,
-      object.data?.color,
-      object.data?.emitRate,
-      object.data?.spreadRadius,                 // spreadR
-      object.data?.spreadY ?? 0.03,              // вертикальний джиттер
-      (object.data?.baseSize ?? 10.0) / 10.0,    // sizeMul від uPointSize=10
-      object.data?.spreadGrow ?? 0.25,           // розгін по XZ з висотою
-      (object.data?.riseHeight ?? object.data?.rise ?? 2.0), // висота підйому
-      alpha,
-      object.data?.alphaDiminish ?? object.data?.alphaFade ?? 0.0 // NEW
+      params.position,
+      params.color,
+      params.emitRate,
+      params.spreadR,
+      params.spreadY,
+      params.sizeMul,
+      params.spreadGrow,
+      params.riseHeight,
+      params.alphaMul,
+      params.alphaDiminish
     );
+    this.emitterParams.set(object.id, params);
     this.addMesh(object.id, this.points);
     (this.points as any).__emitterIndexMap = (this.points as any).__emitterIndexMap || new Map<string, number>();
     (this.points as any).__emitterIndexMap.set(object.id, idx);
@@ -639,20 +747,21 @@ export class SmokeRenderer extends BaseRenderer {
     const map: Map<string, number> = (this.points as any).__emitterIndexMap;
     const idx = map?.get(object.id);
     if (idx !== undefined && idx >= 0) {
-      const alpha = (object.data?.alphaMul ?? object.data?.opacity);
+      const params = this.extractEmitterParams(object);
       this.moveEmitter(
         idx,
-        object.coordinates,
-        object.data?.color,
-        object.data?.emitRate,
-        object.data?.spreadRadius,
-        object.data?.spreadY,
-        (object.data?.baseSize !== undefined) ? (object.data.baseSize / 10.0) : undefined,
-        object.data?.spreadGrow,
-        (object.data?.riseHeight ?? object.data?.rise),
-        alpha,
-        (object.data?.alphaDiminish ?? object.data?.alphaFade)
+        params.position,
+        params.color,
+        params.emitRate,
+        params.spreadR,
+        params.spreadY,
+        params.sizeMul,
+        params.spreadGrow,
+        params.riseHeight,
+        params.alphaMul,
+        params.alphaDiminish
       );
+      this.emitterParams.set(object.id, params);
     }
   }
 
@@ -663,6 +772,8 @@ export class SmokeRenderer extends BaseRenderer {
       this.setEmitterActive(idx, false);
       map.delete(id);
     }
+
+    this.emitterParams.delete(id);
   }
 
   dispose(): void {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { TerrainManager } from '@scene/terrain-manager';
 import { MAP_CONFIG } from '@systems/map';
 import { TextureManager } from './TextureManager';
+import type { ShadowQuality } from '@systems/graphics';
 
 export class TerrainRenderer {
   private scene: THREE.Scene;
@@ -24,6 +25,8 @@ export class TerrainRenderer {
 
   // Кеш списку текстур для блендів (щоб не перевизначати атрибути щоразу)
   private cachedTextureNames: string[] = [];
+
+  private shadowMode: ShadowQuality = 'pseudo';
 
   constructor(scene: THREE.Scene, terrainManager: TerrainManager, loadingManager?: THREE.LoadingManager) {
     this.scene = scene;
@@ -69,7 +72,7 @@ export class TerrainRenderer {
       this.terrainMesh = new THREE.Mesh(this.geometry, this.material);
       this.terrainMesh.matrixAutoUpdate = true;
       this.terrainMesh.castShadow = false;
-      this.terrainMesh.receiveShadow = true;
+      this.terrainMesh.receiveShadow = this.shadowMode === 'detailed';
       this.terrainMesh.frustumCulled = true;
 
       this.scene.add(this.terrainMesh);
@@ -131,6 +134,13 @@ export class TerrainRenderer {
 
   getTerrainMesh(): THREE.Mesh | null {
     return this.terrainMesh;
+  }
+
+  public setShadowMode(mode: ShadowQuality): void {
+    this.shadowMode = mode;
+    if (this.terrainMesh) {
+      this.terrainMesh.receiveShadow = mode === 'detailed';
+    }
   }
 
   // === ВНУТРІШНЄ ===================================================================

--- a/src/ui/screens/colony/scene/Scene3D/renderers/utils/bakedShadows.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/utils/bakedShadows.ts
@@ -1,0 +1,146 @@
+import * as THREE from 'three';
+
+const SHADOW_NAME = '__bakedShadow';
+const SHADOW_GEOMETRY = new THREE.PlaneGeometry(1, 1);
+let SHADOW_TEXTURE: THREE.DataTexture | null = null;
+
+function createShadowTexture(size = 256, falloff = 1.6): THREE.DataTexture {
+  const data = new Uint8Array(size * size * 4);
+  const half = size / 2;
+  const maxRadius = half * Math.SQRT2;
+
+  let ptr = 0;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x + 0.5 - half;
+      const dy = y + 0.5 - half;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const norm = Math.min(1, dist / maxRadius);
+      const intensity = Math.pow(1 - norm, falloff);
+      const alpha = Math.min(255, Math.max(0, Math.floor(255 * intensity)));
+
+      data[ptr++] = 0;
+      data[ptr++] = 0;
+      data[ptr++] = 0;
+      data[ptr++] = alpha;
+    }
+  }
+
+  const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearFilter;
+  texture.generateMipmaps = false;
+
+  return texture;
+}
+
+function ensureTexture(): THREE.Texture {
+  if (!SHADOW_TEXTURE) {
+    SHADOW_TEXTURE = createShadowTexture();
+  }
+  return SHADOW_TEXTURE;
+}
+
+function disposeMesh(mesh: THREE.Object3D | null | undefined) {
+  if (!mesh || !(mesh instanceof THREE.Mesh)) return;
+  const material = mesh.material;
+  if (Array.isArray(material)) {
+    material.forEach((m) => m.dispose());
+  } else {
+    (material as THREE.Material).dispose();
+  }
+}
+
+export interface BakedShadowConfig {
+  width: number;
+  depth: number;
+  minY: number;
+  centerX?: number;
+  centerZ?: number;
+  intensity?: number;
+  softness?: number;
+  offset?: number;
+  color?: THREE.ColorRepresentation;
+  minSize?: number;
+}
+
+export function applyBakedShadow(target: THREE.Object3D, config: BakedShadowConfig): void {
+  const existing = target.getObjectByName(SHADOW_NAME);
+  if (existing) {
+    target.remove(existing);
+    disposeMesh(existing);
+  }
+
+  const texture = ensureTexture();
+  const intensity = THREE.MathUtils.clamp(config.intensity ?? 0.6, 0, 1);
+  const softness = config.softness ?? 1.3;
+  const minSize = config.minSize ?? 0.5;
+  const baseWidth = Number.isFinite(config.width) ? Math.abs(config.width) : 0;
+  const baseDepth = Number.isFinite(config.depth) ? Math.abs(config.depth) : 0;
+  const width = Math.max(minSize, baseWidth * softness);
+  const depth = Math.max(minSize, baseDepth * softness);
+
+  const centerX = Number.isFinite(config.centerX ?? NaN) ? config.centerX! : 0;
+  const centerZ = Number.isFinite(config.centerZ ?? NaN) ? config.centerZ! : 0;
+  const minY = Number.isFinite(config.minY) ? config.minY : 0;
+  const offsetWorld = config.offset ?? 0.015;
+  const parentScaleY = Math.max(1e-6, target.scale?.y ?? 1);
+  const offsetLocal = offsetWorld / parentScaleY;
+
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    color: new THREE.Color(config.color ?? 0x000000),
+    transparent: true,
+    opacity: intensity,
+    depthWrite: false,
+    toneMapped: false,
+    blending: THREE.MultiplyBlending,
+    side: THREE.DoubleSide,
+  });
+
+  const plane = new THREE.Mesh(SHADOW_GEOMETRY, material);
+  plane.name = SHADOW_NAME;
+  plane.rotation.x = -Math.PI / 2;
+  plane.position.set(centerX, minY + offsetLocal, centerZ);
+  plane.scale.set(width, depth, 1);
+  plane.renderOrder = -5;
+  plane.matrixAutoUpdate = true;
+  plane.castShadow = false;
+  plane.receiveShadow = false;
+  plane.userData.bakedShadow = true;
+  plane.layers.mask = target.layers.mask;
+
+  target.add(plane);
+}
+
+export function removeBakedShadow(target: THREE.Object3D): void {
+  const existing = target.getObjectByName(SHADOW_NAME);
+  if (existing) {
+    target.remove(existing);
+    disposeMesh(existing);
+  }
+}
+
+export function computeShadowFootprint(source: THREE.Object3D): {
+  width: number;
+  depth: number;
+  minY: number;
+  centerX: number;
+  centerZ: number;
+} {
+  source.updateWorldMatrix(true, true);
+  const box = new THREE.Box3().setFromObject(source);
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+
+  return {
+    width: size.x,
+    depth: size.z,
+    minY: box.min.y,
+    centerX: center.x,
+    centerZ: center.z,
+  };
+}

--- a/src/ui/screens/colony/scene/components/VerticalMenuWithContext.tsx
+++ b/src/ui/screens/colony/scene/components/VerticalMenuWithContext.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { VerticalMenu } from '@ui/shared';
 import { useUpgradesMenuButton } from '@ui/screens/colony/upgrades/UpgradesPanel';
 import { useBuildingsMenuButton } from '@ui/screens/colony/buildings/BuildingsPanel';
+import { useGraphicsSettingsMenuButton } from '@ui/screens/colony/settings';
 
 interface VerticalMenuWithContextProps {
   game: any;
@@ -13,6 +14,7 @@ export const VerticalMenuWithContext: React.FC<VerticalMenuWithContextProps> = (
   const buildingsMenu = useBuildingsMenuButton(game, (typeId: string) => {
     console.log(`Selected building for construction: ${typeId}`);
   });
+  const graphicsSettingsMenu = useGraphicsSettingsMenuButton(game.graphicsSettings);
 
   return (
     <>
@@ -32,12 +34,14 @@ export const VerticalMenuWithContext: React.FC<VerticalMenuWithContextProps> = (
             onClick: () => game.saveToCurrentSlot(),
             title: 'Зберегти гру'
           },
+          graphicsSettingsMenu.button,
           upgradesMenu.button,
           buildingsMenu.button
         ]}
       />
 
       {/* Modals */}
+      {graphicsSettingsMenu.modal}
       {upgradesMenu.modal}
       {buildingsMenu.modal}
     </>

--- a/src/ui/screens/colony/scene/hooks/useSceneCore.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneCore.ts
@@ -10,7 +10,7 @@ export function useSceneCore() {
     const dir = new THREE.DirectionalLight(0xffffff, 0.85);
     dir.position.set(80, 120, 60);
     dir.castShadow = true;
-    dir.shadow.mapSize.set(2048, 2048);
+    dir.shadow.mapSize.set(1024, 1024);
     dir.shadow.bias = -0.0005;
 
     const shadowCam = dir.shadow.camera as THREE.OrthographicCamera;
@@ -38,7 +38,7 @@ export function useSceneCore() {
   const renderer = useMemo(() => {
     const r = new THREE.WebGLRenderer({ antialias: true });
     r.setSize(window.innerWidth, window.innerHeight);
-    r.shadowMap.enabled = true;
+    r.shadowMap.enabled = false;
     r.shadowMap.type = THREE.PCFSoftShadowMap;
     return r;
   }, []);

--- a/src/ui/screens/colony/scene/hooks/useSceneManagers.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneManagers.ts
@@ -7,13 +7,15 @@ import { AreaSelectionRenderer } from '@ui/screens/colony/scene/AreaSelectionRen
 import { createUiLogicBridge } from '@ui/logic/UiLogicBridge';
 import { IMapLogic } from '@interfaces/index';
 import { SceneLoadingManager } from '../Scene3D/loading/SceneLoadingManager';
+import type { GraphicsSettingsManager } from '@systems/graphics';
 
 export function useSceneManagers(
   scene: THREE.Scene,
   camera: THREE.PerspectiveCamera,
   renderer: THREE.WebGLRenderer,
   appMapLogic: IMapLogic,
-  loadingManager?: SceneLoadingManager
+  loadingManager: SceneLoadingManager | undefined,
+  graphicsSettings: GraphicsSettingsManager
 ) {
   const rendererManagerRef = useRef<RendererManager | null>(null);
   const selectionRendererRef = useRef<SelectionRenderer | null>(null);
@@ -26,6 +28,7 @@ export function useSceneManagers(
     const bridge = createUiLogicBridge(appMapLogic);
     const manager = loadingManager?.getLoadingManager();
     rendererManagerRef.current = new RendererManager(scene, renderer, bridge, manager);
+    rendererManagerRef.current.attachGraphicsSettings(graphicsSettings);
     mapLogicRef.current = appMapLogic;
 
     selectionRendererRef.current = new SelectionRenderer(
@@ -61,7 +64,7 @@ export function useSceneManagers(
 
       setManagersReady(false);
     };
-  }, [scene, camera, renderer, appMapLogic, loadingManager]);
+  }, [scene, camera, renderer, appMapLogic, loadingManager, graphicsSettings]);
 
   return {
     rendererManagerRef,

--- a/src/ui/screens/colony/settings/GraphicsSettingsModal.css
+++ b/src/ui/screens/colony/settings/GraphicsSettingsModal.css
@@ -1,0 +1,84 @@
+.graphics-settings-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #f0f0f0;
+}
+
+.graphics-settings-tabs {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 8px;
+}
+
+.graphics-settings-tab {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.graphics-settings-tab.is-active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+.graphics-settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.graphics-settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.graphics-settings-section-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.graphics-settings-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.graphics-settings-option {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.graphics-settings-option input {
+  margin-top: 5px;
+}
+
+.graphics-settings-option-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.graphics-settings-option-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.graphics-settings-option-description {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}

--- a/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
+++ b/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { Modal } from '@ui/shared/Modal';
+import type { GraphicsSettingsState, ParticleQuality, ShadowQuality } from '@systems/graphics';
+import './GraphicsSettingsModal.css';
+
+interface GraphicsSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  settings: GraphicsSettingsState;
+  onChange: (changes: Partial<GraphicsSettingsState>) => void;
+}
+
+const SHADOW_OPTIONS: Array<{ value: ShadowQuality; label: string; description: string }> = [
+  {
+    value: 'detailed',
+    label: 'Детальні',
+    description: 'Увімкнути динамічні тіні для будівель та біомаси.'
+  },
+  {
+    value: 'pseudo',
+    label: 'Псевдо-тіні',
+    description: 'Спрощені випечені плями без навантаження на тіньову карту.'
+  },
+  {
+    value: 'none',
+    label: 'Відсутні',
+    description: 'Повністю вимкнути тіні від об’єктів.'
+  }
+];
+
+const PARTICLE_OPTIONS: Array<{ value: ParticleQuality; label: string; description: string }> = [
+  {
+    value: 'high',
+    label: 'Висока якість',
+    description: 'Максимальна кількість частинок, текстури 128×128.'
+  },
+  {
+    value: 'low',
+    label: 'Низька якість',
+    description: 'Текстури 64×64, удвічі більші спрайти та зменшений спавн.'
+  }
+];
+
+export const GraphicsSettingsModal: React.FC<GraphicsSettingsModalProps> = ({
+  isOpen,
+  onClose,
+  settings,
+  onChange
+}) => {
+  const [activeTab, setActiveTab] = useState<'graphics'>('graphics');
+
+  const handleShadowChange = (value: ShadowQuality) => {
+    if (value !== settings.shadows) {
+      onChange({ shadows: value });
+    }
+  };
+
+  const handleParticleChange = (value: ParticleQuality) => {
+    if (value !== settings.particles) {
+      onChange({ particles: value });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Налаштування" size="medium">
+      <div className="graphics-settings-modal">
+        <div className="graphics-settings-tabs">
+          <button
+            type="button"
+            className={`graphics-settings-tab${activeTab === 'graphics' ? ' is-active' : ''}`}
+            onClick={() => setActiveTab('graphics')}
+          >
+            Графіка
+          </button>
+        </div>
+
+        {activeTab === 'graphics' && (
+          <div className="graphics-settings-content">
+            <section className="graphics-settings-section">
+              <h3 className="graphics-settings-section-title">Тіні</h3>
+              <div className="graphics-settings-options">
+                {SHADOW_OPTIONS.map(option => (
+                  <label key={option.value} className="graphics-settings-option">
+                    <input
+                      type="radio"
+                      name="shadow-quality"
+                      value={option.value}
+                      checked={settings.shadows === option.value}
+                      onChange={() => handleShadowChange(option.value)}
+                    />
+                    <div className="graphics-settings-option-body">
+                      <span className="graphics-settings-option-label">{option.label}</span>
+                      <span className="graphics-settings-option-description">{option.description}</span>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <section className="graphics-settings-section">
+              <h3 className="graphics-settings-section-title">Частинки</h3>
+              <div className="graphics-settings-options">
+                {PARTICLE_OPTIONS.map(option => (
+                  <label key={option.value} className="graphics-settings-option">
+                    <input
+                      type="radio"
+                      name="particle-quality"
+                      value={option.value}
+                      checked={settings.particles === option.value}
+                      onChange={() => handleParticleChange(option.value)}
+                    />
+                    <div className="graphics-settings-option-body">
+                      <span className="graphics-settings-option-label">{option.label}</span>
+                      <span className="graphics-settings-option-description">{option.description}</span>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </section>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/src/ui/screens/colony/settings/index.ts
+++ b/src/ui/screens/colony/settings/index.ts
@@ -1,0 +1,2 @@
+export { GraphicsSettingsModal } from './GraphicsSettingsModal';
+export { useGraphicsSettingsMenuButton } from './useGraphicsSettingsMenuButton';

--- a/src/ui/screens/colony/settings/useGraphicsSettingsMenuButton.tsx
+++ b/src/ui/screens/colony/settings/useGraphicsSettingsMenuButton.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import type { GraphicsSettingsManager, GraphicsSettingsState } from '@systems/graphics';
+import { GraphicsSettingsModal } from './GraphicsSettingsModal';
+
+export const useGraphicsSettingsMenuButton = (graphicsSettings: GraphicsSettingsManager) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [settings, setSettings] = useState<GraphicsSettingsState>(graphicsSettings.getState());
+
+  useEffect(() => graphicsSettings.subscribe(setSettings), [graphicsSettings]);
+
+  const handleChange = (changes: Partial<GraphicsSettingsState>) => {
+    graphicsSettings.update(changes);
+  };
+
+  return {
+    button: {
+      id: 'graphics-settings',
+      iconId: 'interface/settings.svg',
+      variant: 'primary' as const,
+      onClick: () => setIsOpen(true),
+      title: 'Налаштування графіки',
+      visible: true
+    },
+    modal: (
+      <GraphicsSettingsModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        settings={settings}
+        onChange={handleChange}
+      />
+    )
+  };
+};


### PR DESCRIPTION
## Summary
- introduce a GraphicsSettingsManager with save/load support and expose it from Game so renderers can react to persisted state
- hook RendererManager, terrain, buildings, biomass, smoke, and fire renderers up to shadow and particle quality switches driven by the manager
- add a graphics settings modal/button to the colony vertical menu along with a settings icon asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a42924748320a5461526c0ac9710