### PR TITLE
Add configurable rover dust trails and graphics toggle

### DIFF
--- a/src/logic/modules/drones/DroneManager.ts
+++ b/src/logic/modules/drones/DroneManager.ts
@@ -1,22 +1,18 @@
 import { TSceneObject } from '@scene/scene.types';
 import { Vector3 } from '@utils/vector-math';
 import { SaveLoadManager, DroneSaveData } from '@save-load/save-load.types';
-import { DRONE_TYPES_DB, DroneTypeData } from './drone-db';
+import { DRONE_TYPES_DB } from './drone-db';
+import type { DroneTypeData, DroneDustTrailConfig } from './drone.types';
 import { IDroneManager, IBonusSystem, ISceneLogic } from '@interfaces/index';
 
-export interface Drone {
-    id: string;
-    position: Vector3;
-    status: 'idle' | 'busy' | 'charging';
-    currentCommandId?: string;
-    battery: number;
-    maxBattery: number;
-    inventory: Record<string, number>;
-    maxInventory: number;
-    efficiency: number;
-    speed: number;
-    maxSpeed: number;
-}
+const DEFAULT_DUST_TRAIL: DroneDustTrailConfig = {
+    enabled: false,
+    particleSize: 0.45,
+    emissionRate: 16,
+    lifetime: 1.4,
+    maxParticles: 60,
+    color: '#bca98f'
+};
 
 export class DroneManager implements SaveLoadManager, IDroneManager {
     private scene: ISceneLogic;
@@ -68,8 +64,11 @@ export class DroneManager implements SaveLoadManager, IDroneManager {
                 modelPath: droneDBData.ui.modelPath || '/models/playtest-rover.glb',
                 scale: 0.4,
                 rotatable: true,
-                rotationOffset: droneDBData.ui.rotationOffset,                
+                rotationOffset: droneDBData.ui.rotationOffset,
                 status: 'idle',
+                dustTrail: droneDBData.dustTrail
+                    ? { ...droneDBData.dustTrail }
+                    : { ...DEFAULT_DUST_TRAIL, enabled: false },
             } as any,
             tags: ['on-ground', 'dynamic', 'rover', 'controlled'],
             bottomAnchor: -0.1,
@@ -102,6 +101,8 @@ export class DroneManager implements SaveLoadManager, IDroneManager {
         drone.data.maxPower = droneDBData.baseBatteryCapacity * this.bonusSystem.getEffectValue('drone_max_battery');
         drone.data.unloadSpeed = droneDBData.baseUnloadSpeed;
         drone.data.efficiencyMultiplier = droneDBData.baseEfficiencyMultiplier;
+
+        this.applyDustTrailDefaults(drone, droneDBData.dustTrail);
 
         if(!drone.data.isReady && setInitials) {
             // Перша ініціалізація
@@ -358,12 +359,13 @@ export class DroneManager implements SaveLoadManager, IDroneManager {
             status: drone.data.status || 'idle',
             currentCommandId: drone.data.currentCommandId,
             battery: drone.data.power || 0,
-            inventory: { ...drone.data.storage }
+            inventory: { ...drone.data.storage },
+            dustTrail: drone.data.dustTrail ? { ...drone.data.dustTrail } : undefined
         }));
-        
+
         return { drones };
     }
-    
+
     load(data: DroneSaveData): void {
         if (data.drones) {
             // Спочатку видаляємо всіх існуючих дронів
@@ -383,10 +385,11 @@ export class DroneManager implements SaveLoadManager, IDroneManager {
                     drone.data.currentCommandId = droneData.currentCommandId;
                     drone.data.power = droneData.battery;
                     drone.data.storage = droneData.inventory;
-                    
-                    // 🚀 Позначаємо як dirty після завантаження даних
-                    // (createDrone вже позначає як dirty, але тут ми оновлюємо додаткові дані)
-                    this.markDroneDirty(droneData.id);
+                    if (droneData.dustTrail) {
+                        drone.data.dustTrail = { ...droneData.dustTrail } as any;
+                    }
+
+                    this.updateDroneData(droneData.id);
                 }
             });
         }
@@ -414,6 +417,35 @@ export class DroneManager implements SaveLoadManager, IDroneManager {
 
         // Також можна викликати метод SceneLogic для маркування
         // this.scene.markObjectDirty(id); // Якщо SceneLogic має публічний метод
+    }
+
+    private applyDustTrailDefaults(drone: TSceneObject, defaults?: DroneDustTrailConfig): void {
+        const data: any = drone.data ?? {};
+        const target: Partial<DroneDustTrailConfig> = data.dustTrail || {};
+        const base: DroneDustTrailConfig = defaults
+            ? { ...defaults }
+            : { ...DEFAULT_DUST_TRAIL, enabled: false };
+
+        if (target.enabled === undefined) {
+            target.enabled = base.enabled;
+        }
+        if (target.particleSize === undefined) {
+            target.particleSize = base.particleSize;
+        }
+        if (target.emissionRate === undefined) {
+            target.emissionRate = base.emissionRate;
+        }
+        if (target.lifetime === undefined) {
+            target.lifetime = base.lifetime;
+        }
+        if (target.maxParticles === undefined && base.maxParticles !== undefined) {
+            target.maxParticles = base.maxParticles;
+        }
+        if (target.color === undefined && base.color !== undefined) {
+            target.color = base.color;
+        }
+
+        data.dustTrail = target;
     }
 
     /**

--- a/src/logic/modules/drones/drone-db.ts
+++ b/src/logic/modules/drones/drone-db.ts
@@ -1,23 +1,6 @@
-export interface DroneTypeData {
-    id: string;
-    name: string;
-    description: string;
-    baseMovementSpeed: number;
-    baseCollectionSpeed: number;
-    baseInventoryCapacity: number;
-    baseUnloadSpeed: number;
-    baseLoadSpeed: number;        // Швидкість завантаження ресурсів зі складу
-    baseBuildSpeed: number;       // Швидкість будівництва
-    baseBatteryCapacity: number;
-    baseEfficiencyMultiplier: number;
-    ui: {
-        defaultScale: { x: number; y: number; z: number };
-        rotationOffset: number;
-        iconName: string;
-        color: string;
-        modelPath?: string;
-    };
-}
+import type { DroneTypeData } from './drone.types';
+
+export type { DroneDustTrailConfig, DroneTypeData } from './drone.types';
 
 // База даних типів дронів
 export const DRONE_TYPES_DB: Map<string, DroneTypeData> = new Map([
@@ -39,6 +22,14 @@ export const DRONE_TYPES_DB: Map<string, DroneTypeData> = new Map([
             rotationOffset: 0,
             iconName: 'rover-icon.png',
             color: '#4A90E2'
+        },
+        dustTrail: {
+            enabled: true,
+            particleSize: 0.45,
+            emissionRate: 18,
+            lifetime: 1.4,
+            maxParticles: 60,
+            color: '#bca98f'
         }
     }],
     
@@ -59,6 +50,14 @@ export const DRONE_TYPES_DB: Map<string, DroneTypeData> = new Map([
             rotationOffset: 0,
             iconName: 'advanced-rover-icon.png',
             color: '#7B68EE'
+        },
+        dustTrail: {
+            enabled: true,
+            particleSize: 0.5,
+            emissionRate: 22,
+            lifetime: 1.6,
+            maxParticles: 80,
+            color: '#c8b08c'
         }
     }],
     
@@ -79,6 +78,14 @@ export const DRONE_TYPES_DB: Map<string, DroneTypeData> = new Map([
             rotationOffset: 0,
             iconName: 'heavy-rover-icon.png',
             color: '#8B4513'
+        },
+        dustTrail: {
+            enabled: false,
+            particleSize: 0.55,
+            emissionRate: 14,
+            lifetime: 1.8,
+            maxParticles: 70,
+            color: '#978065'
         }
     }]
 ]);

--- a/src/logic/modules/drones/drone-db.ts
+++ b/src/logic/modules/drones/drone-db.ts
@@ -25,9 +25,9 @@ export const DRONE_TYPES_DB: Map<string, DroneTypeData> = new Map([
         },
         dustTrail: {
             enabled: true,
-            particleSize: 0.45,
+            particleSize: 0.65,
             emissionRate: 18,
-            lifetime: 1.4,
+            lifetime: 1.2,
             maxParticles: 60,
             color: '#bca98f'
         }

--- a/src/logic/modules/drones/drone.types.ts
+++ b/src/logic/modules/drones/drone.types.ts
@@ -1,0 +1,47 @@
+import type { Vector3 } from '@utils/vector-math';
+
+export interface DroneDustTrailConfig {
+    enabled: boolean;
+    particleSize: number;
+    emissionRate: number;
+    lifetime: number;
+    maxParticles?: number;
+    color?: string;
+}
+
+export interface DroneTypeData {
+    id: string;
+    name: string;
+    description: string;
+    baseMovementSpeed: number;
+    baseCollectionSpeed: number;
+    baseInventoryCapacity: number;
+    baseUnloadSpeed: number;
+    baseLoadSpeed: number;        // Швидкість завантаження ресурсів зі складу
+    baseBuildSpeed: number;       // Швидкість будівництва
+    baseBatteryCapacity: number;
+    baseEfficiencyMultiplier: number;
+    ui: {
+        defaultScale: { x: number; y: number; z: number };
+        rotationOffset: number;
+        iconName: string;
+        color: string;
+        modelPath?: string;
+    };
+    dustTrail?: DroneDustTrailConfig;
+}
+
+export interface Drone {
+    id: string;
+    position: Vector3;
+    status: 'idle' | 'busy' | 'charging';
+    currentCommandId?: string;
+    battery: number;
+    maxBattery: number;
+    inventory: Record<string, number>;
+    maxInventory: number;
+    efficiency: number;
+    speed: number;
+    maxSpeed: number;
+    dustTrail?: DroneDustTrailConfig;
+}

--- a/src/logic/modules/drones/index.ts
+++ b/src/logic/modules/drones/index.ts
@@ -1,2 +1,2 @@
 export { DroneManager } from './DroneManager';
-export type { Drone } from './DroneManager';
+export type { Drone, DroneDustTrailConfig, DroneTypeData } from './drone.types';

--- a/src/logic/systems/commands/executors/MoveToExecutor.ts
+++ b/src/logic/systems/commands/executors/MoveToExecutor.ts
@@ -193,6 +193,26 @@ export class MoveToExecutor extends CommandExecutor {
         const pathfindingSystem = this.context.scene.pathfinder;
         if (pathfindingSystem) {
             const roadSpeedBonus = pathfindingSystem.getSpeedBonusAtWorld(currentPos.x, currentPos.z);
+            if (!object.data) {
+                object.data = {};
+            }
+            const prevBonus = object.data.roadSpeedBonus ?? 1;
+            const prevOnRoad = !!object.data.isOnRoad;
+            const isOnRoad = roadSpeedBonus > 1.05;
+
+            object.data.roadSpeedBonus = roadSpeedBonus;
+            object.data.isOnRoad = isOnRoad;
+
+            if (Math.abs(prevBonus - roadSpeedBonus) > 0.05 || prevOnRoad !== isOnRoad) {
+                if (object._dirtyFlags) {
+                    object._dirtyFlags.data = true;
+                    object._lastUpdate = Date.now();
+                }
+                if (this.context.scene.markObjectDirty) {
+                    this.context.scene.markObjectDirty(object.id);
+                }
+            }
+
             if (roadSpeedBonus > 1.0) {
                 speed *= roadSpeedBonus;
             }

--- a/src/logic/systems/graphics/GraphicsSettingsManager.ts
+++ b/src/logic/systems/graphics/GraphicsSettingsManager.ts
@@ -6,11 +6,13 @@ export type ParticleQuality = 'high' | 'low';
 export interface GraphicsSettingsState {
   shadows: ShadowQuality;
   particles: ParticleQuality;
+  droneDustTrails: boolean;
 }
 
 const DEFAULT_SETTINGS: GraphicsSettingsState = {
   shadows: 'pseudo',
   particles: 'high',
+  droneDustTrails: true,
 };
 
 type Listener = (state: GraphicsSettingsState) => void;
@@ -37,7 +39,11 @@ export class GraphicsSettingsManager implements SaveLoadManager {
 
   public update(partial: Partial<GraphicsSettingsState>): void {
     const next: GraphicsSettingsState = { ...this.state, ...partial };
-    if (next.shadows === this.state.shadows && next.particles === this.state.particles) {
+    if (
+      next.shadows === this.state.shadows &&
+      next.particles === this.state.particles &&
+      next.droneDustTrails === this.state.droneDustTrails
+    ) {
       return;
     }
     this.state = next;
@@ -72,6 +78,7 @@ export class GraphicsSettingsManager implements SaveLoadManager {
     const next: GraphicsSettingsState = {
       shadows: this.parseShadowQuality((data as GraphicsSettingsState).shadows),
       particles: this.parseParticleQuality((data as GraphicsSettingsState).particles),
+      droneDustTrails: this.parseDroneDustTrails((data as GraphicsSettingsState).droneDustTrails),
     };
 
     this.state = next;
@@ -95,5 +102,18 @@ export class GraphicsSettingsManager implements SaveLoadManager {
       return value;
     }
     return DEFAULT_SETTINGS.particles;
+  }
+
+  public setDroneDustTrails(enabled: boolean): void {
+    if (this.state.droneDustTrails === enabled) return;
+    this.state = { ...this.state, droneDustTrails: enabled };
+    this.emit();
+  }
+
+  private parseDroneDustTrails(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    return DEFAULT_SETTINGS.droneDustTrails;
   }
 }

--- a/src/logic/systems/save-load/save-load.types.ts
+++ b/src/logic/systems/save-load/save-load.types.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from '@utils/vector-math';
+import type { DroneDustTrailConfig } from '@drones/drone.types';
 import { EnvironmentSaveData } from '@systems/environment/environment.types';
 import type { GraphicsSettingsState } from '@systems/graphics';
 
@@ -93,6 +94,7 @@ export interface DroneSaveData {
         currentCommandId?: string;
         battery: number;
         inventory: Record<string, number>;
+        dustTrail?: Partial<DroneDustTrailConfig>;
     }>;
 }
 

--- a/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
+++ b/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
@@ -145,7 +145,8 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
   useEffect(() => {
     if (!managersReady) return;
     rendererManagerRef.current?.setParticleQuality(graphicsSettingsState.particles);
-  }, [graphicsSettingsState.particles, rendererManagerRef, managersReady]);
+    rendererManagerRef.current?.setDustTrailsEnabled(graphicsSettingsState.droneDustTrails);
+  }, [graphicsSettingsState.particles, graphicsSettingsState.droneDustTrails, rendererManagerRef, managersReady]);
 
   useEffect(() => {
     const map = mapLogicRef.current;

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -29,6 +29,7 @@ export class RendererManager {
     private graphicsSettingsUnsubscribe: (() => void) | null = null;
     private shadowMode: ShadowQuality | null = null;
     private particleQuality: ParticleQuality | null = null;
+    private dustTrailsEnabled: boolean = true;
 
     constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer, bridge?: UiLogicBridge, loadingManager?: THREE.LoadingManager) {
         this.scene = scene;
@@ -62,7 +63,12 @@ export class RendererManager {
             usePaletteBuckets: true
         })); // Каменюки типу rock з звичайним рендерингом
         this.registerRenderer('biomass', new BiomassRenderer(this.scene)); // Біомаса
-        this.registerRenderer('rover', new RoverRenderer(this.scene)); // Rover об'єкти
+        const roverRenderer = new RoverRenderer(this.scene);
+        if (this.particleQuality) {
+            roverRenderer.setParticleQuality(this.particleQuality);
+        }
+        roverRenderer.setDustTrailsEnabled(this.dustTrailsEnabled);
+        this.registerRenderer('rover', roverRenderer); // Rover об'єкти
         const buildingRenderer = new BuildingRenderer(this.scene, this.renderer, this.loadingManager || undefined);
         if (this.bridge && (buildingRenderer as any).setUiLogicBridge) {
             (buildingRenderer as any).setUiLogicBridge(this.bridge);
@@ -171,6 +177,7 @@ export class RendererManager {
         this.graphicsSettingsUnsubscribe = manager.subscribe((state) => {
             this.setShadowMode(state.shadows);
             this.setParticleQuality(state.particles);
+            this.setDustTrailsEnabled(state.droneDustTrails);
         });
     }
 
@@ -188,5 +195,13 @@ export class RendererManager {
         smokeRenderer?.setQuality?.(quality);
         const fireRenderer = this.renderers.get('fire') as any;
         fireRenderer?.setQuality?.(quality);
+        const roverRenderer = this.renderers.get('rover') as any;
+        roverRenderer?.setParticleQuality?.(quality);
+    }
+
+    public setDustTrailsEnabled(enabled: boolean): void {
+        this.dustTrailsEnabled = enabled;
+        const roverRenderer = this.renderers.get('rover') as any;
+        roverRenderer?.setDustTrailsEnabled?.(enabled);
     }
 }

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoverRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoverRenderer.ts
@@ -264,9 +264,9 @@ class DustTrailEmitter {
     this.positions[base + 1] = spawnPos.y;
     this.positions[base + 2] = spawnPos.z;
 
-    const baseSpeed = Math.min(this.state.speed * 0.55 + Math.random() * 0.6, 4.5);
+    const baseSpeed = Math.min(this.state.speed * 0.15 + Math.random() * 0.3, 0.5);
     this.velocities[base] = -dir.x * baseSpeed + (Math.random() - 0.5) * 0.4;
-    this.velocities[base + 1] = 0.8 + Math.random() * 0.6;
+    this.velocities[base + 1] = 0.3 + Math.random() * 0.2;
     this.velocities[base + 2] = -dir.z * baseSpeed + (Math.random() - 0.5) * 0.4;
   }
 

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoverRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoverRenderer.ts
@@ -4,6 +4,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { BaseRenderer } from './BaseRenderer';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
+import type { ParticleQuality } from '@systems/graphics';
 
 export interface RoverData {
   modelPath?: string;
@@ -17,6 +18,18 @@ export interface RoverData {
   power?: number;
   maxPower?: number;
   animationId?: string | null; // FIX: ідентифікатор кліпу для програвання
+  dustTrail?: RoverDustTrailConfig;
+  roadSpeedBonus?: number;
+  isOnRoad?: boolean;
+}
+
+interface RoverDustTrailConfig {
+  enabled?: boolean;
+  particleSize?: number;
+  emissionRate?: number;
+  lifetime?: number;
+  maxParticles?: number;
+  color?: string;
 }
 
 type ProgressBarOpts = {
@@ -37,13 +50,295 @@ const BAR_WIDTH = 0.2;
 const BAR_HEIGHT = 0.018;
 const GAP_Y = 0.41; // відстань між power і resource барами
 
+const FALLBACK_DUST_TRAIL: Required<RoverDustTrailConfig> = {
+  enabled: false,
+  particleSize: 0.45,
+  emissionRate: 16,
+  lifetime: 1.4,
+  maxParticles: 60,
+  color: '#bca98f'
+};
+
+const _tmpVecA = new THREE.Vector3();
+const _tmpVecB = new THREE.Vector3();
+const _tmpVecC = new THREE.Vector3(0, 0, 1);
+const _tmpVecD = new THREE.Vector3();
+
+class DustTrailEmitter {
+  private static spriteTexture: THREE.Texture | null = null;
+
+  private readonly scene: THREE.Scene;
+  private geometry: THREE.BufferGeometry;
+  private material: THREE.PointsMaterial;
+  private points: THREE.Points;
+  private positions: Float32Array;
+  private velocities: Float32Array;
+  private ages: Float32Array;
+  private lifetimes: Float32Array;
+  private active: Uint8Array;
+  private activeCount = 0;
+  private emissionAccumulator = 0;
+  private capacity: number;
+  private config: Required<RoverDustTrailConfig>;
+  private globalEnabled = true;
+  private qualityMultiplier = 1;
+
+  private readonly state = {
+    position: new THREE.Vector3(),
+    direction: new THREE.Vector3(0, 0, 1),
+    speed: 0,
+    shouldEmit: false
+  };
+
+  private static spawnLateral = new THREE.Vector3();
+  private static spawnPos = new THREE.Vector3();
+
+  constructor(scene: THREE.Scene, config: RoverDustTrailConfig | undefined, quality: ParticleQuality) {
+    this.scene = scene;
+    this.config = this.buildConfig(config);
+    this.capacity = Math.max(8, Math.floor(this.config.maxParticles));
+    this.positions = new Float32Array(this.capacity * 3);
+    this.velocities = new Float32Array(this.capacity * 3);
+    this.ages = new Float32Array(this.capacity);
+    this.lifetimes = new Float32Array(this.capacity);
+    this.active = new Uint8Array(this.capacity);
+
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setAttribute('position', new THREE.BufferAttribute(this.positions, 3));
+
+    this.material = new THREE.PointsMaterial({
+      size: this.config.particleSize,
+      map: DustTrailEmitter.getSpriteTexture(),
+      transparent: true,
+      opacity: 0.35,
+      depthWrite: false,
+      depthTest: true,
+      color: new THREE.Color(this.config.color),
+      sizeAttenuation: true,
+      blending: THREE.NormalBlending,
+      alphaTest: 0.05,
+    });
+
+    this.points = new THREE.Points(this.geometry, this.material);
+    this.points.frustumCulled = false;
+    this.points.renderOrder = 1;
+    this.scene.add(this.points);
+
+    this.qualityMultiplier = quality === 'high' ? 1 : 0.6;
+    this.hideAllParticles();
+  }
+
+  private buildConfig(config?: RoverDustTrailConfig): Required<RoverDustTrailConfig> {
+    return {
+      enabled: config?.enabled ?? FALLBACK_DUST_TRAIL.enabled,
+      particleSize: config?.particleSize ?? FALLBACK_DUST_TRAIL.particleSize,
+      emissionRate: config?.emissionRate ?? FALLBACK_DUST_TRAIL.emissionRate,
+      lifetime: config?.lifetime ?? FALLBACK_DUST_TRAIL.lifetime,
+      maxParticles: config?.maxParticles ?? FALLBACK_DUST_TRAIL.maxParticles,
+      color: config?.color ?? FALLBACK_DUST_TRAIL.color
+    };
+  }
+
+  public updateConfig(config: RoverDustTrailConfig | undefined, quality: ParticleQuality): void {
+    const next = this.buildConfig(config);
+    const needsResize = next.maxParticles > this.capacity;
+    this.config = next;
+    this.qualityMultiplier = quality === 'high' ? 1 : 0.6;
+    this.material.size = next.particleSize;
+    this.material.color.set(next.color);
+
+    if (needsResize) {
+      this.rebuildGeometry(Math.floor(next.maxParticles));
+    }
+  }
+
+  public setState(position: THREE.Vector3, direction: THREE.Vector3, speed: number, shouldEmit: boolean): void {
+    this.state.position.copy(position);
+    this.state.direction.copy(direction);
+    this.state.speed = speed;
+    this.state.shouldEmit = shouldEmit;
+  }
+
+  public tick(delta: number): void {
+    if (delta <= 0) return;
+
+    const gravity = 1.5;
+    for (let i = 0; i < this.capacity; i++) {
+      if (!this.active[i]) continue;
+      this.ages[i] += delta;
+      if (this.ages[i] >= this.lifetimes[i]) {
+        this.active[i] = 0;
+        this.activeCount = Math.max(0, this.activeCount - 1);
+        this.hideParticle(i);
+        continue;
+      }
+
+      const base = i * 3;
+      this.positions[base] += this.velocities[base] * delta;
+      this.positions[base + 1] += this.velocities[base + 1] * delta;
+      this.positions[base + 2] += this.velocities[base + 2] * delta;
+
+      this.velocities[base] *= 0.92;
+      this.velocities[base + 2] *= 0.92;
+      this.velocities[base + 1] -= gravity * delta;
+    }
+
+    if (this.globalEnabled && this.state.shouldEmit) {
+      const effectiveRate = this.config.emissionRate * this.qualityMultiplier;
+      this.emissionAccumulator += effectiveRate * delta;
+      const spawnCount = Math.floor(this.emissionAccumulator);
+      this.emissionAccumulator -= spawnCount;
+      for (let i = 0; i < spawnCount; i++) {
+        this.spawnParticle();
+      }
+    } else {
+      this.emissionAccumulator = 0;
+    }
+
+    this.points.visible = this.globalEnabled && (this.state.shouldEmit || this.activeCount > 0);
+    (this.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  }
+
+  public setGlobalEnabled(enabled: boolean): void {
+    this.globalEnabled = enabled;
+    if (!enabled) {
+      this.points.visible = false;
+    }
+  }
+
+  public setQuality(quality: ParticleQuality): void {
+    this.qualityMultiplier = quality === 'high' ? 1 : 0.6;
+  }
+
+  public dispose(): void {
+    this.scene.remove(this.points);
+    this.geometry.dispose();
+    this.material.dispose();
+  }
+
+  private hideParticle(index: number): void {
+    const base = index * 3;
+    this.positions[base] = this.state.position.x;
+    this.positions[base + 1] = -9999;
+    this.positions[base + 2] = this.state.position.z;
+  }
+
+  private hideAllParticles(): void {
+    for (let i = 0; i < this.capacity; i++) {
+      this.active[i] = 0;
+      this.ages[i] = 0;
+      this.lifetimes[i] = 0;
+      this.hideParticle(i);
+    }
+    this.activeCount = 0;
+    (this.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  }
+
+  private spawnParticle(): void {
+    const index = this.findAvailableIndex();
+    if (index === -1) {
+      return;
+    }
+
+    this.active[index] = 1;
+    this.ages[index] = 0;
+    this.lifetimes[index] = this.config.lifetime * (0.7 + Math.random() * 0.6);
+    this.activeCount++;
+
+    const base = index * 3;
+    const dir = this.state.direction;
+    const lateral = DustTrailEmitter.spawnLateral.set(dir.z, 0, -dir.x);
+    if (lateral.lengthSq() > 1e-4) {
+      lateral.normalize().multiplyScalar((Math.random() - 0.5) * 0.6);
+    } else {
+      lateral.set((Math.random() - 0.5) * 0.3, 0, (Math.random() - 0.5) * 0.3);
+    }
+
+    const spawnPos = DustTrailEmitter.spawnPos
+      .copy(this.state.position)
+      .addScaledVector(dir, -0.25 - Math.random() * 0.2)
+      .add(lateral);
+    spawnPos.y += Math.random() * 0.12;
+
+    this.positions[base] = spawnPos.x;
+    this.positions[base + 1] = spawnPos.y;
+    this.positions[base + 2] = spawnPos.z;
+
+    const baseSpeed = Math.min(this.state.speed * 0.55 + Math.random() * 0.6, 4.5);
+    this.velocities[base] = -dir.x * baseSpeed + (Math.random() - 0.5) * 0.4;
+    this.velocities[base + 1] = 0.8 + Math.random() * 0.6;
+    this.velocities[base + 2] = -dir.z * baseSpeed + (Math.random() - 0.5) * 0.4;
+  }
+
+  private findAvailableIndex(): number {
+    for (let i = 0; i < this.capacity; i++) {
+      if (!this.active[i]) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private rebuildGeometry(newCapacity: number): void {
+    const capacity = Math.max(this.capacity, Math.floor(newCapacity));
+    if (capacity === this.capacity) return;
+
+    this.capacity = capacity;
+    this.positions = new Float32Array(this.capacity * 3);
+    this.velocities = new Float32Array(this.capacity * 3);
+    this.ages = new Float32Array(this.capacity);
+    this.lifetimes = new Float32Array(this.capacity);
+    this.active = new Uint8Array(this.capacity);
+    this.activeCount = 0;
+    this.emissionAccumulator = 0;
+
+    const newGeometry = new THREE.BufferGeometry();
+    newGeometry.setAttribute('position', new THREE.BufferAttribute(this.positions, 3));
+
+    this.geometry.dispose();
+    this.geometry = newGeometry;
+    this.points.geometry = newGeometry;
+
+    this.hideAllParticles();
+  }
+
+  private static getSpriteTexture(): THREE.Texture {
+    if (DustTrailEmitter.spriteTexture) {
+      return DustTrailEmitter.spriteTexture;
+    }
+
+    const size = 64;
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+      gradient.addColorStop(0, 'rgba(255,255,255,1)');
+      gradient.addColorStop(1, 'rgba(255,255,255,0)');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, size, size);
+    }
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.needsUpdate = true;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    DustTrailEmitter.spriteTexture = texture;
+    return texture;
+  }
+}
+
 export class RoverRenderer extends BaseRenderer {
   private loader: GLTFLoader;
   private modelCache: Map<string, THREE.Group> = new Map();
   // FIX: окремо кешуємо кліпи
   private animCache: Map<string, THREE.AnimationClip[]> = new Map();
   // FIX: свій clock для mixer.update()
-  private clock = new THREE.Clock();
+  private animationClock = new THREE.Clock();
+  private dustClock = new THREE.Clock();
+  private dustEmitters: Map<string, DustTrailEmitter> = new Map();
+  private dustTrailsEnabled = true;
+  private particleQuality: ParticleQuality = 'high';
 
   constructor(scene: THREE.Scene) {
     super(scene);
@@ -67,6 +362,7 @@ export class RoverRenderer extends BaseRenderer {
       const cachedModel = this.modelCache.get(modelPath)!;
       const mesh = this.createRoverMesh(cachedModel, roverData);
       this.setupMesh(mesh, object);
+      this.initializeTrailTracking(mesh);
       this.addMesh(object.id, mesh);
 
       // Бар ресурсів та бар енергії — створюємо після додавання у сцену
@@ -95,6 +391,7 @@ export class RoverRenderer extends BaseRenderer {
         console.log('anims: ', gltf.animations);
         const mesh = this.createRoverMesh(gltf.scene, roverData);
         this.setupMesh(mesh, object);
+        this.initializeTrailTracking(mesh);
 
         // замінюємо fallback (+ прибираємо його індикатори)
         const prev = this.meshes.get(object.id) as THREE.Mesh | undefined;
@@ -132,6 +429,7 @@ export class RoverRenderer extends BaseRenderer {
     // Fallback
     const fallbackMesh = this.createFallbackMesh(roverData);
     this.setupMesh(fallbackMesh, object);
+    this.initializeTrailTracking(fallbackMesh);
     this.addMesh(object.id, fallbackMesh);
 
     // і для fallback теж після addMesh:
@@ -181,6 +479,28 @@ export class RoverRenderer extends BaseRenderer {
     mesh.userData.barY = bbox.max.y + 0.15 * modelHeight;
 
     return mesh;
+  }
+
+  private initializeTrailTracking(mesh: THREE.Mesh): void {
+    const now = performance.now() * 0.001;
+    mesh.updateMatrixWorld(true);
+    if (!mesh.userData.prevPosition) {
+      mesh.userData.prevPosition = mesh.position.clone();
+    } else {
+      (mesh.userData.prevPosition as THREE.Vector3).copy(mesh.position);
+    }
+    mesh.userData.prevTimestamp = now;
+    const dir = mesh.getWorldDirection(_tmpVecB.set(0, 0, 0));
+    if (dir.lengthSq() < 1e-6) {
+      dir.set(0, 0, 1);
+    } else {
+      dir.normalize();
+    }
+    if (!mesh.userData.lastDirection) {
+      mesh.userData.lastDirection = dir.clone();
+    } else {
+      (mesh.userData.lastDirection as THREE.Vector3).copy(dir);
+    }
   }
 
   // -------------------------
@@ -464,6 +784,75 @@ export class RoverRenderer extends BaseRenderer {
     mesh.receiveShadow = false;
   }
 
+  private updateDustTrailState(object: TSceneObject, mesh: THREE.Mesh): void {
+    const now = performance.now() * 0.001;
+    const prevTimestamp = (mesh.userData.prevTimestamp as number | undefined) ?? now;
+    const deltaTime = Math.max(1e-3, now - prevTimestamp);
+    let prevPosition = mesh.userData.prevPosition as THREE.Vector3 | undefined;
+    if (!prevPosition) {
+      prevPosition = mesh.position.clone();
+      mesh.userData.prevPosition = prevPosition;
+    }
+
+    _tmpVecD.copy(mesh.position).sub(prevPosition);
+    const distance = _tmpVecD.length();
+
+    let direction: THREE.Vector3;
+    if (distance > 1e-4) {
+      _tmpVecD.multiplyScalar(1 / distance);
+      direction = _tmpVecD;
+      if (!mesh.userData.lastDirection) {
+        mesh.userData.lastDirection = direction.clone();
+      } else {
+        (mesh.userData.lastDirection as THREE.Vector3).copy(direction);
+      }
+    } else {
+      const stored = mesh.userData.lastDirection as THREE.Vector3 | undefined;
+      if (stored) {
+        direction = stored;
+      } else {
+        direction = _tmpVecC.set(0, 0, 1);
+        mesh.userData.lastDirection = direction.clone();
+      }
+    }
+
+    const speed = distance / deltaTime;
+    prevPosition.copy(mesh.position);
+    mesh.userData.prevTimestamp = now;
+
+    const roverData = (object.data as RoverData) || {};
+    const roadBonus = roverData.roadSpeedBonus ?? 1;
+    const isOnRoad = roverData.isOnRoad ?? roadBonus > 1.05;
+    const shouldEmit = !isOnRoad && speed > 0.25;
+
+    const config = roverData.dustTrail;
+    const shouldHaveEmitter = this.dustTrailsEnabled && !!config && config.enabled !== false;
+    const existingEmitter = this.dustEmitters.get(object.id);
+
+    if (!shouldHaveEmitter) {
+      if (existingEmitter) {
+        existingEmitter.dispose();
+        this.dustEmitters.delete(object.id);
+      }
+      return;
+    }
+
+    let emitter = existingEmitter;
+    if (!emitter) {
+      emitter = new DustTrailEmitter(this.scene, config, this.particleQuality);
+      emitter.setGlobalEnabled(this.dustTrailsEnabled);
+      this.dustEmitters.set(object.id, emitter);
+    } else {
+      emitter.updateConfig(config, this.particleQuality);
+      emitter.setGlobalEnabled(this.dustTrailsEnabled);
+    }
+
+    _tmpVecA.copy(mesh.position);
+    _tmpVecA.y += 0.05;
+
+    emitter.setState(_tmpVecA, direction, speed, shouldEmit);
+  }
+
   // -------------------------
   // Tick/Update
   // -------------------------
@@ -476,8 +865,11 @@ export class RoverRenderer extends BaseRenderer {
     this.updatePowerBar(existingMesh, object.data as RoverData);
 
     // FIX: оновлюємо mixer + керуємо animationId
+    const delta = this.animationClock.getDelta();
     const mixer = existingMesh.userData.mixer as THREE.AnimationMixer | undefined;
-    if (mixer) mixer.update(this.clock.getDelta());
+    if (mixer) mixer.update(delta);
+
+    this.updateDustTrailState(object, existingMesh);
 
     const actions = existingMesh.userData.actions as Record<string, THREE.AnimationAction> | undefined;
     if (!actions) return;
@@ -498,6 +890,32 @@ export class RoverRenderer extends BaseRenderer {
     next.reset().fadeIn(fade).play();
     if (current && actions[current]) actions[current].crossFadeTo(next, fade, false);
     existingMesh.userData.currentAction = want;
+  }
+
+  public updateDustTrails(): void {
+    const delta = this.dustClock.getDelta();
+    if (delta <= 0) {
+      return;
+    }
+    for (const emitter of this.dustEmitters.values()) {
+      emitter.tick(delta);
+    }
+  }
+
+  public setDustTrailsEnabled(enabled: boolean): void {
+    if (this.dustTrailsEnabled === enabled) return;
+    this.dustTrailsEnabled = enabled;
+    for (const emitter of this.dustEmitters.values()) {
+      emitter.setGlobalEnabled(enabled);
+    }
+  }
+
+  public setParticleQuality(quality: ParticleQuality): void {
+    if (this.particleQuality === quality) return;
+    this.particleQuality = quality;
+    for (const emitter of this.dustEmitters.values()) {
+      emitter.setQuality(quality);
+    }
   }
 
   // -------------------------
@@ -525,8 +943,22 @@ export class RoverRenderer extends BaseRenderer {
     // Очищаємо кеш моделей
     this.modelCache.clear();
     this.animCache.clear(); // FIX
-    
+
     // Очищаємо меші
     this.meshes.clear();
+
+    for (const emitter of this.dustEmitters.values()) {
+      emitter.dispose();
+    }
+    this.dustEmitters.clear();
+  }
+
+  public override remove(id: string): void {
+    const emitter = this.dustEmitters.get(id);
+    if (emitter) {
+      emitter.dispose();
+      this.dustEmitters.delete(id);
+    }
+    super.remove(id);
   }
 }

--- a/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
+++ b/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
@@ -81,6 +81,7 @@ export function useRenderLoop(
       tryCall('explosion', 'updateAllExplosions');
       tryCall('electric-arc', 'updateAllArcs');
       tryCall('aurora', 'updateEnvironmentEffects');
+      tryCall('rover', 'updateDustTrails');
     }
 
     const lights = (scene as THREE.Scene & {

--- a/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
+++ b/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
@@ -61,6 +61,12 @@ export const GraphicsSettingsModal: React.FC<GraphicsSettingsModalProps> = ({
     }
   };
 
+  const handleDustToggle = (value: boolean) => {
+    if (value !== settings.droneDustTrails) {
+      onChange({ droneDustTrails: value });
+    }
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Налаштування" size="medium">
       <div className="graphics-settings-modal">
@@ -115,6 +121,20 @@ export const GraphicsSettingsModal: React.FC<GraphicsSettingsModalProps> = ({
                     </div>
                   </label>
                 ))}
+                <label className="graphics-settings-option">
+                  <input
+                    type="checkbox"
+                    name="drone-dust-trails"
+                    checked={settings.droneDustTrails}
+                    onChange={(event) => handleDustToggle(event.target.checked)}
+                  />
+                  <div className="graphics-settings-option-body">
+                    <span className="graphics-settings-option-label">Сліди пилюки дронів</span>
+                    <span className="graphics-settings-option-description">
+                      Увімкнути ефект пилу позаду дронів під час руху поза дорогами.
+                    </span>
+                  </div>
+                </label>
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- add per-type drone dust trail defaults and persist individual overrides
- detect road usage during movement and drive rover dust emitters off-road only
- expose a graphics setting for drone dust trails and update the renderer pipeline to support it
- centralize drone-related type definitions for reuse across logic modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38a1ec760832084bbfe3ff0bfa914