### PR TITLE
Add dynamic sky cloud rendering

### DIFF
--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -7,6 +7,10 @@ import {
   EnvironmentSaveData,
   EnvironmentState,
   IEnvironmentEffect,
+  SkyCloudConfig,
+  SkyCloudLayerConfig,
+  SkyCloudObjectData,
+  SkyCloudRenderState,
   SunLightState,
   SunVisualConfig,
 } from './environment.types';
@@ -48,6 +52,7 @@ const DEFAULT_CONFIG: EnvironmentConfig = {
       changeIntervalHours: 3,
       transitionSeconds: 12,
     },
+    cloudyFactor: 0.35,
   },
   dustClouds: {
     initialCount: 2,
@@ -59,6 +64,56 @@ const DEFAULT_CONFIG: EnvironmentConfig = {
     windSpeed: { min: 0.3, max: 1.0 },
     particleCount: 200,
     color: 0xd2b46c,
+  },
+  skyClouds: {
+    initialCloudyFactor: 0.35,
+    smoothingSeconds: 25,
+    globalSpeedMultiplier: 0.8,
+    globalWispyMultiplier: 1.0,
+    globalOpacityMultiplier: 1.0,
+    coverageExponent: 1.35,
+    windDirectionDeg: 15,
+    parallaxRange: { min: 0.7, max: 1.35 },
+    layers: [
+      {
+        id: 'stratus',
+        altitude: 110,
+        altitudeJitter: 18,
+        maxCount: 22,
+        areaMultiplier: 1.35,
+        sizeRange: { min: 160, max: 260 },
+        aspectRatioRange: { min: 1.4, max: 2.2 },
+        opacityRange: { min: 0.35, max: 0.65 },
+        speedRange: { min: 0.45, max: 0.9 },
+        directionJitterDeg: 12,
+        wispinessRange: { min: 0.35, max: 0.6 },
+        softnessRange: { min: 0.14, max: 0.24 },
+        noiseScaleRange: { min: 1.6, max: 2.4 },
+        noiseStrengthRange: { min: 0.8, max: 1.3 },
+        color: 0xd9d2c5,
+        colorVariance: 0.12,
+        coverageWeight: 1.2,
+      },
+      {
+        id: 'cirrus',
+        altitude: 165,
+        altitudeJitter: 26,
+        maxCount: 18,
+        areaMultiplier: 1.6,
+        sizeRange: { min: 200, max: 320 },
+        aspectRatioRange: { min: 2.2, max: 3.4 },
+        opacityRange: { min: 0.18, max: 0.38 },
+        speedRange: { min: 0.9, max: 1.6 },
+        directionJitterDeg: 18,
+        wispinessRange: { min: 0.6, max: 0.92 },
+        softnessRange: { min: 0.2, max: 0.34 },
+        noiseScaleRange: { min: 2.3, max: 3.2 },
+        noiseStrengthRange: { min: 0.9, max: 1.5 },
+        color: 0xf3f0ea,
+        colorVariance: 0.08,
+        coverageWeight: 0.85,
+      },
+    ],
   },
   sun: {
     altitudeRangeDeg: { min: 6, max: 45 },
@@ -94,6 +149,12 @@ export class EnvironmentLogic {
   private dustCloudIdCounter = 0;
   private dustClouds: Map<string, { createdAt: number; ttl: number }> = new Map();
 
+  private skyCloudIdCounter = 0;
+  private skyClouds: Set<string> = new Set();
+
+  private cloudyFactor = 0;
+  private cloudyTarget = 0;
+
   private initialized = false;
 
   private time = {
@@ -107,6 +168,8 @@ export class EnvironmentLogic {
     windSpeed: 0,
     windTarget: 0,
     nextWindChangeMinute: 0,
+    cloudyFactor: 0,
+    cloudyTarget: 0,
   };
 
   private state: EnvironmentState;
@@ -129,6 +192,14 @@ export class EnvironmentLogic {
     this.weather.nextWindChangeMinute =
       this.time.totalMinutes + windRange.changeIntervalHours * 60;
 
+    const initialCloudiness =
+      this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0;
+    const clampedCloudiness = this.clamp(initialCloudiness, 0, 1);
+    this.weather.cloudyFactor = clampedCloudiness;
+    this.weather.cloudyTarget = clampedCloudiness;
+    this.cloudyFactor = clampedCloudiness;
+    this.cloudyTarget = clampedCloudiness;
+
     this.state = this.buildEnvironmentState();
   }
 
@@ -139,6 +210,7 @@ export class EnvironmentLogic {
     this.initialized = true;
     this.clearAllEffects();
     this.clearDustClouds();
+    this.clearSkyClouds();
     this.dustCloudTimer = 0;
 
     const startTotalMinutes =
@@ -153,6 +225,15 @@ export class EnvironmentLogic {
     this.weather.nextWindChangeMinute =
       this.time.totalMinutes + windRange.changeIntervalHours * 60;
 
+    const startCloudiness =
+      this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0;
+    const clampedCloudiness = this.clamp(startCloudiness, 0, 1);
+    this.weather.cloudyFactor = clampedCloudiness;
+    this.weather.cloudyTarget = clampedCloudiness;
+    this.cloudyFactor = clampedCloudiness;
+    this.cloudyTarget = clampedCloudiness;
+
+    this.generateSkyClouds();
     this.generateInitialDustClouds();
     this.state = this.buildEnvironmentState();
   }
@@ -168,6 +249,7 @@ export class EnvironmentLogic {
     this.advanceTime(deltaTimeSeconds);
     this.updateWeather(deltaTimeSeconds);
     this.updateDustClouds(deltaTimeSeconds);
+    this.updateCloudyFactor(deltaTimeSeconds);
 
     const now = Date.now();
     if (now - this.lastUpdateTime >= this.config.updateInterval) {
@@ -230,6 +312,45 @@ export class EnvironmentLogic {
   }
 
   /**
+   * Параметри для шейдера небесних хмар
+   */
+  getSkyCloudRenderState(): SkyCloudRenderState {
+    const skyConfig = this.config.skyClouds;
+    const windRange = this.config.weather.windSpeed;
+    const windSpan = Math.max(0.0001, windRange.max - windRange.min);
+    const normalizedWind = this.clamp(
+      (this.weather.windSpeed - windRange.min) / windSpan,
+      0,
+      1
+    );
+
+    const speedMultiplier = skyConfig.globalSpeedMultiplier * this.lerp(0.6, 1.45, normalizedWind);
+
+    return {
+      cloudyFactor: this.cloudyFactor,
+      speedMultiplier,
+      wispyMultiplier: skyConfig.globalWispyMultiplier,
+      opacityMultiplier: skyConfig.globalOpacityMultiplier,
+    };
+  }
+
+  /**
+   * Поточний рівень хмарності (0..1)
+   */
+  getCloudyFactor(): number {
+    return this.cloudyFactor;
+  }
+
+  /**
+   * Встановити нову цільову хмарність (0..1)
+   */
+  setCloudyFactor(value: number): void {
+    const clamped = this.clamp(value, 0, 1);
+    this.cloudyTarget = clamped;
+    this.weather.cloudyTarget = clamped;
+  }
+
+  /**
    * Оновити налаштування вигляду сонця
    */
   updateSunVisualConfig(update: Partial<SunVisualConfig>): void {
@@ -247,6 +368,7 @@ export class EnvironmentLogic {
         windSpeed: this.weather.windSpeed,
         windTarget: this.weather.windTarget,
         nextWindChangeMinute: this.weather.nextWindChangeMinute,
+        cloudyFactor: this.weather.cloudyTarget,
       },
     };
   }
@@ -271,6 +393,13 @@ export class EnvironmentLogic {
       }
       if (typeof data.weather.nextWindChangeMinute === 'number') {
         this.weather.nextWindChangeMinute = data.weather.nextWindChangeMinute;
+      }
+      if (typeof data.weather.cloudyFactor === 'number') {
+        const clamped = this.clamp(data.weather.cloudyFactor, 0, 1);
+        this.weather.cloudyFactor = clamped;
+        this.weather.cloudyTarget = clamped;
+        this.cloudyFactor = clamped;
+        this.cloudyTarget = clamped;
       }
     }
 
@@ -329,43 +458,65 @@ export class EnvironmentLogic {
   // ──────────────────────────────
 
   private mergeConfig(base: EnvironmentConfig, overrides?: Partial<EnvironmentConfig>): EnvironmentConfig {
-    if (!overrides) {
-      return base;
-    }
-
-    const merged: EnvironmentConfig = {
+    const cloned: EnvironmentConfig = {
       ...base,
-      ...overrides,
-      aurora: { ...base.aurora, ...(overrides.aurora ?? {}) },
-      mapSize: { ...base.mapSize, ...(overrides.mapSize ?? {}) },
-      time: { ...base.time, ...(overrides.time ?? {}) },
+      aurora: { ...base.aurora },
+      mapSize: { ...base.mapSize },
+      time: { ...base.time },
       weather: {
-        temperature: {
-          ...base.weather.temperature,
-          ...(overrides.weather?.temperature ?? {}),
-        },
-        windSpeed: {
-          ...base.weather.windSpeed,
-          ...(overrides.weather?.windSpeed ?? {}),
-        },
+        temperature: { ...base.weather.temperature },
+        windSpeed: { ...base.weather.windSpeed },
+        cloudyFactor: base.weather.cloudyFactor,
       },
       dustClouds: {
         ...base.dustClouds,
+        size: { ...base.dustClouds.size },
+        height: { ...base.dustClouds.height },
+        windSpeed: { ...base.dustClouds.windSpeed },
+      },
+      skyClouds: this.mergeSkyCloudConfig(base.skyClouds),
+      sun: this.mergeSunConfig(base.sun),
+    };
+
+    if (!overrides) {
+      return cloned;
+    }
+
+    const merged: EnvironmentConfig = {
+      ...cloned,
+      ...overrides,
+      aurora: { ...cloned.aurora, ...(overrides.aurora ?? {}) },
+      mapSize: { ...cloned.mapSize, ...(overrides.mapSize ?? {}) },
+      time: { ...cloned.time, ...(overrides.time ?? {}) },
+      weather: {
+        temperature: {
+          ...cloned.weather.temperature,
+          ...(overrides.weather?.temperature ?? {}),
+        },
+        windSpeed: {
+          ...cloned.weather.windSpeed,
+          ...(overrides.weather?.windSpeed ?? {}),
+        },
+        cloudyFactor: overrides.weather?.cloudyFactor ?? cloned.weather.cloudyFactor,
+      },
+      dustClouds: {
+        ...cloned.dustClouds,
         ...(overrides.dustClouds ?? {}),
         size: {
-          ...base.dustClouds.size,
+          ...cloned.dustClouds.size,
           ...(overrides.dustClouds?.size ?? {}),
         },
         height: {
-          ...base.dustClouds.height,
+          ...cloned.dustClouds.height,
           ...(overrides.dustClouds?.height ?? {}),
         },
         windSpeed: {
-          ...base.dustClouds.windSpeed,
+          ...cloned.dustClouds.windSpeed,
           ...(overrides.dustClouds?.windSpeed ?? {}),
         },
       },
-      sun: this.mergeSunConfig(base.sun, overrides.sun),
+      skyClouds: this.mergeSkyCloudConfig(cloned.skyClouds, overrides.skyClouds),
+      sun: this.mergeSunConfig(cloned.sun, overrides.sun),
     };
 
     return merged;
@@ -396,6 +547,47 @@ export class EnvironmentLogic {
         ...base.colors,
         ...(overrides.colors ?? {}),
       },
+    };
+  }
+
+  private mergeSkyCloudConfig(base: SkyCloudConfig, overrides?: Partial<SkyCloudConfig>): SkyCloudConfig {
+    const cloned: SkyCloudConfig = {
+      ...base,
+      parallaxRange: { ...base.parallaxRange },
+      layers: base.layers.map((layer) => this.cloneSkyCloudLayer(layer)),
+    };
+
+    if (!overrides) {
+      return cloned;
+    }
+
+    const merged: SkyCloudConfig = {
+      ...cloned,
+      ...overrides,
+      parallaxRange: {
+        ...cloned.parallaxRange,
+        ...(overrides.parallaxRange ?? {}),
+      },
+    };
+
+    if (overrides.layers) {
+      merged.layers = overrides.layers.map((layer) => this.cloneSkyCloudLayer(layer));
+    }
+
+    return merged;
+  }
+
+  private cloneSkyCloudLayer(layer: SkyCloudLayerConfig): SkyCloudLayerConfig {
+    return {
+      ...layer,
+      sizeRange: { ...layer.sizeRange },
+      aspectRatioRange: { ...layer.aspectRatioRange },
+      opacityRange: { ...layer.opacityRange },
+      speedRange: { ...layer.speedRange },
+      wispinessRange: { ...layer.wispinessRange },
+      softnessRange: { ...layer.softnessRange },
+      noiseScaleRange: { ...layer.noiseScaleRange },
+      noiseStrengthRange: { ...layer.noiseStrengthRange },
     };
   }
 
@@ -456,6 +648,20 @@ export class EnvironmentLogic {
         this.dustClouds.delete(cloudId);
       }
     }
+  }
+
+  private updateCloudyFactor(deltaTimeSeconds: number): void {
+    const diff = this.cloudyTarget - this.cloudyFactor;
+    if (Math.abs(diff) < 0.0001) {
+      this.cloudyFactor = this.cloudyTarget;
+      this.weather.cloudyFactor = this.cloudyFactor;
+      return;
+    }
+
+    const smoothing = Math.max(0.1, this.config.skyClouds.smoothingSeconds);
+    const step = this.clamp(deltaTimeSeconds / smoothing, 0, 1);
+    this.cloudyFactor += diff * step;
+    this.weather.cloudyFactor = this.cloudyFactor;
   }
 
   private cleanupExpiredEffects(now: number): void {
@@ -579,6 +785,85 @@ export class EnvironmentLogic {
     this.dustCloudIdCounter = 0;
   }
 
+  private clearSkyClouds(): void {
+    for (const cloudId of this.skyClouds) {
+      this.scene.removeObject(cloudId);
+    }
+    this.skyClouds.clear();
+    this.skyCloudIdCounter = 0;
+  }
+
+  private generateSkyClouds(): void {
+    const cfg = this.config.skyClouds;
+    if (!cfg) return;
+
+    this.clearSkyClouds();
+
+    const maxDimension = Math.max(this.config.mapSize.width, this.config.mapSize.depth);
+
+    for (const layer of cfg.layers) {
+      const radius = maxDimension * 0.5 * layer.areaMultiplier;
+      for (let i = 0; i < layer.maxCount; i++) {
+        const cloudId = `sky_cloud_${layer.id}_${++this.skyCloudIdCounter}`;
+        const angle = Math.random() * Math.PI * 2;
+        const distance = Math.sqrt(Math.random()) * radius;
+        const x = Math.cos(angle) * distance;
+        const z = Math.sin(angle) * distance;
+        const altitude =
+          layer.altitude + this.randomBetween(-layer.altitudeJitter * 0.5, layer.altitudeJitter * 0.5);
+        const heightOffset = this.randomBetween(-layer.altitudeJitter * 0.25, layer.altitudeJitter * 0.25);
+
+        const size = this.randomBetween(layer.sizeRange.min, layer.sizeRange.max);
+        const aspect = this.randomBetween(layer.aspectRatioRange.min, layer.aspectRatioRange.max);
+        const opacity = this.randomBetween(layer.opacityRange.min, layer.opacityRange.max);
+        const wispiness = this.randomBetween(layer.wispinessRange.min, layer.wispinessRange.max);
+        const softness = this.randomBetween(layer.softnessRange.min, layer.softnessRange.max);
+        const noiseScale = this.randomBetween(layer.noiseScaleRange.min, layer.noiseScaleRange.max);
+        const noiseStrength = this.randomBetween(layer.noiseStrengthRange.min, layer.noiseStrengthRange.max);
+        const speed = this.randomBetween(layer.speedRange.min, layer.speedRange.max);
+        const directionBase = this.degToRad(cfg.windDirectionDeg);
+        const direction =
+          directionBase + this.degToRad(this.randomBetween(-layer.directionJitterDeg, layer.directionJitterDeg));
+        const colorShift = (Math.random() - 0.5) * 2 * layer.colorVariance;
+        const activation = Math.pow(Math.random(), Math.max(0.0001, layer.coverageWeight));
+        const parallax = this.randomBetween(cfg.parallaxRange.min, cfg.parallaxRange.max);
+
+        const cloud: TSceneObject<SkyCloudObjectData> = {
+          id: cloudId,
+          type: 'sky-cloud',
+          coordinates: { x, y: altitude, z },
+          scale: { x: 1, y: 1, z: 1 },
+          rotation: { x: 0, y: 0, z: 0 },
+          data: {
+            layerId: layer.id,
+            seed: Math.random() * 1000,
+            size,
+            aspectRatio: aspect,
+            opacity,
+            wispiness,
+            softness,
+            noiseScale,
+            noiseStrength,
+            color: layer.color,
+            colorShift,
+            speed,
+            direction,
+            activation,
+            parallax,
+            heightOffset,
+            boundsRadius: radius,
+          },
+          tags: ['sky', 'cloud', 'environment'],
+          bottomAnchor: 0,
+          terrainAlign: false,
+        };
+
+        this.scene.pushObject(cloud);
+        this.skyClouds.add(cloudId);
+      }
+    }
+  }
+
   private buildEnvironmentState(): EnvironmentState {
     const minutes = this.time.currentMinutes;
     const hour = Math.floor(minutes / 60);
@@ -597,6 +882,7 @@ export class EnvironmentLogic {
       },
       temperature: this.weather.temperature,
       windSpeed: this.weather.windSpeed,
+      cloudiness: this.cloudyFactor,
       isNight: this.isNightTime(),
       sun,
     };
@@ -637,7 +923,11 @@ export class EnvironmentLogic {
     }
 
     intensity = this.clamp(intensity, 0, 1);
-    const ambientIntensity = 0.18 + intensity * 0.35;
+    const coverageExponent = this.config.skyClouds.coverageExponent ?? 1;
+    const cloudiness = Math.pow(this.clamp(this.cloudyFactor, 0, 1), coverageExponent);
+    let ambientIntensity = 0.18 + intensity * 0.35;
+    ambientIntensity *= this.lerp(1, 1.25, cloudiness * 0.7);
+    const directionalIntensity = intensity * this.lerp(1, 0.45, cloudiness);
 
     const dayMinutes = 1440;
     const fullProgress = (this.time.totalMinutes % dayMinutes) / dayMinutes;
@@ -678,6 +968,9 @@ export class EnvironmentLogic {
       sunColor = this.lerpColor(sunColor, sunsetColor, sunsetWeight);
     }
 
+    const overcastTint = this.hexToRgb(0xe2e6ea);
+    sunColor = this.lerpColor(sunColor, overcastTint, cloudiness * 0.45);
+
     let haloColor = { ...haloBase };
     if (sunriseWeight > 0) {
       haloColor = this.lerpColor(haloColor, sunriseColor, sunriseWeight * 0.6);
@@ -685,9 +978,11 @@ export class EnvironmentLogic {
     if (sunsetWeight > 0) {
       haloColor = this.lerpColor(haloColor, sunsetColor, sunsetWeight * 0.6);
     }
+    haloColor = this.lerpColor(haloColor, overcastTint, cloudiness * 0.35);
 
     const white = { r: 1, g: 1, b: 1 };
-    const directionalColor = this.lerpColor(sunColor, white, 0.1 + horizonWeight * 0.2);
+    let directionalColor = this.lerpColor(sunColor, white, 0.1 + horizonWeight * 0.2);
+    directionalColor = this.lerpColor(directionalColor, overcastTint, cloudiness * 0.25);
 
     const horizonFadeDeg = Math.max(0, sunCfg.altitudeRangeDeg.min);
     const altitudeAboveHorizon = Math.max(0, altitudeDeg);
@@ -709,7 +1004,7 @@ export class EnvironmentLogic {
 
     const haloShrinkInfluence = Math.max(horizonInfluence, Math.pow(belowRatio, 0.8));
     const haloSizeMultiplier = this.lerp(1, 0.42, haloShrinkInfluence);
-    const haloSize = sunCfg.haloSize * haloSizeMultiplier;
+    const haloSize = sunCfg.haloSize * haloSizeMultiplier * this.lerp(1, 0.7, cloudiness);
 
     const fadeStartBelow = maxVisibleDropDeg + 5; // Почати зникати на 8° нижче горизонту замість 5°
     const fadeEndBelow = fadeStartBelow + Math.max(2, horizonFadeDeg * 0.5);
@@ -723,20 +1018,41 @@ export class EnvironmentLogic {
       }
     }
 
-    const directionalBrightness = this.clamp(intensity, 0, 1);
+    const directionalBrightness = this.clamp(directionalIntensity, 0, 1);
     const glowPresence = Math.max(horizonWeight, Math.pow(belowRatio, 0.75));
     const discBaseLuminance = 0.7 + Math.max(directionalBrightness, glowPresence) * 0.3;
-    const discOpacity = this.clamp(discBaseLuminance * discVisibility, 0, 1);
-    const haloIntensity = 0; // Вимкнено для тесту
+    const discOpacity = this.clamp(
+      discBaseLuminance * discVisibility * this.lerp(1, 0.35, cloudiness),
+      0,
+      1
+    );
+
+    let haloIntensity = this.lerp(
+      sunCfg.haloIntensity.day,
+      sunCfg.haloIntensity.horizon,
+      horizonInfluence
+    );
+    if (this.isNightTime()) {
+      haloIntensity = this.lerp(haloIntensity, sunCfg.haloIntensity.night, 0.85);
+    } else {
+      haloIntensity = this.lerp(
+        haloIntensity,
+        sunCfg.haloIntensity.night,
+        Math.pow(cloudiness, 1.1) * 0.5
+      );
+    }
+    haloIntensity *= this.lerp(1, 0.25, cloudiness);
 
     // Колір фону в залежності від пори доби
     const dayBackgroundColor = this.hexToRgb(0x7a6f2e);   // Денний колір
     const nightBackgroundColor = this.hexToRgb(0x11130e); // Нічний колір
-    const backgroundColor = this.lerpColor(nightBackgroundColor, dayBackgroundColor, intensity);
-    
+    const baseBackground = this.lerpColor(nightBackgroundColor, dayBackgroundColor, intensity);
+    const overcastBackground = this.hexToRgb(0x4a545d);
+    const backgroundColor = this.lerpColor(baseBackground, overcastBackground, cloudiness * 0.45);
+
     return {
       direction: { x, y, z },
-      directionalIntensity: intensity,
+      directionalIntensity,
       ambientIntensity,
       directionalColor,
       sunColor,
@@ -756,6 +1072,10 @@ export class EnvironmentLogic {
 
   private clamp(value: number, min: number, max: number): number {
     return Math.min(max, Math.max(min, value));
+  }
+
+  private degToRad(value: number): number {
+    return (value * Math.PI) / 180;
   }
 
   private lerp(a: number, b: number, t: number): number {

--- a/src/logic/systems/environment/environment.types.ts
+++ b/src/logic/systems/environment/environment.types.ts
@@ -62,6 +62,7 @@ export interface WindSpeedConfig {
 export interface WeatherConfig {
   temperature: TemperatureRangeConfig;
   windSpeed: WindSpeedConfig;
+  cloudyFactor: number;
 }
 
 export interface DustCloudConfig {
@@ -74,6 +75,65 @@ export interface DustCloudConfig {
   windSpeed: { min: number; max: number };
   particleCount: number;
   color: number;
+}
+
+export interface SkyCloudLayerConfig {
+  id: string;
+  altitude: number;
+  altitudeJitter: number;
+  maxCount: number;
+  areaMultiplier: number;
+  sizeRange: { min: number; max: number };
+  aspectRatioRange: { min: number; max: number };
+  opacityRange: { min: number; max: number };
+  speedRange: { min: number; max: number };
+  directionJitterDeg: number;
+  wispinessRange: { min: number; max: number };
+  softnessRange: { min: number; max: number };
+  noiseScaleRange: { min: number; max: number };
+  noiseStrengthRange: { min: number; max: number };
+  color: number;
+  colorVariance: number;
+  coverageWeight: number;
+}
+
+export interface SkyCloudConfig {
+  initialCloudyFactor: number;
+  smoothingSeconds: number;
+  globalSpeedMultiplier: number;
+  globalWispyMultiplier: number;
+  globalOpacityMultiplier: number;
+  coverageExponent: number;
+  windDirectionDeg: number;
+  parallaxRange: { min: number; max: number };
+  layers: SkyCloudLayerConfig[];
+}
+
+export interface SkyCloudObjectData {
+  layerId: string;
+  seed: number;
+  size: number;
+  aspectRatio: number;
+  opacity: number;
+  wispiness: number;
+  softness: number;
+  noiseScale: number;
+  noiseStrength: number;
+  color: number;
+  colorShift: number;
+  speed: number;
+  direction: number;
+  activation: number;
+  parallax: number;
+  heightOffset: number;
+  boundsRadius: number;
+}
+
+export interface SkyCloudRenderState {
+  cloudyFactor: number;
+  speedMultiplier: number;
+  wispyMultiplier: number;
+  opacityMultiplier: number;
 }
 
 export interface MapSizeConfig {
@@ -111,6 +171,7 @@ export interface EnvironmentState {
   };
   temperature: number;
   windSpeed: number;
+  cloudiness: number;
   isNight: boolean;
   sun: SunLightState;
 }
@@ -141,6 +202,7 @@ export interface EnvironmentSaveData {
     windSpeed: number;
     windTarget: number;
     nextWindChangeMinute: number;
+    cloudyFactor?: number;
   };
 }
 
@@ -173,6 +235,9 @@ export interface EnvironmentConfig {
 
   // Параметри хмар з пилу
   dustClouds: DustCloudConfig;
+
+  // Небесні хмари
+  skyClouds: SkyCloudConfig;
 
   // Параметри вигляду сонця
   sun: SunVisualConfig;

--- a/src/logic/systems/map/map-config.ts
+++ b/src/logic/systems/map/map-config.ts
@@ -107,6 +107,7 @@ export const MAP_CONFIG = {
         weather: {
             temperature: { min: -50, max: 20 },
             windSpeed: { min: 2, max: 18, changeIntervalHours: 2, transitionSeconds: 12 },
+            cloudyFactor: 0.35,
         },
         dustClouds: {
             spawnIntervalSeconds: 60,

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -16,6 +16,7 @@ import { SmokeRenderer } from './SmokeRenderer'
 import { RoadRenderer } from './RoadRenderer'
 import { AuroraRenderer } from './environment/AuroraRenderer'
 import { SunRenderer } from './environment/SunRenderer'
+import { SkyCloudRenderer } from './environment/SkyCloudRenderer'
 // import { ExplosionRenderer } from './ExplosionRenderer'
 
 import type { GraphicsSettingsManager, ParticleQuality, ShadowQuality } from '@systems/graphics'
@@ -77,7 +78,8 @@ export class RendererManager {
             (buildingRenderer as any).setShadowMode?.(this.shadowMode);
         }
         this.registerRenderer('building', buildingRenderer); // Будівлі
-        this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Хмари
+        this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Пилові хмари
+        this.registerRenderer('sky-cloud', new SkyCloudRenderer(this.scene)); // Небесні хмари
         const smokeRenderer = new SmokeRenderer(this.scene, this.renderer);
         if (this.particleQuality) {
             smokeRenderer.setQuality(this.particleQuality);

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/SkyCloudRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/SkyCloudRenderer.ts
@@ -1,0 +1,443 @@
+import * as THREE from 'three';
+import { BaseRenderer } from '../BaseRenderer';
+import { TSceneObject } from '@logic/systems/scene/scene.types';
+import {
+  SkyCloudObjectData,
+  SkyCloudRenderState,
+} from '@logic/systems/environment/environment.types';
+
+interface InternalCloudData {
+  data: SkyCloudObjectData;
+  velocity: THREE.Vector3;
+  boundsRadius: number;
+  basePosition: THREE.Vector3;
+}
+
+type SkyCloudGlobalState = SkyCloudRenderState & {
+  sunDirection: THREE.Vector3;
+  sunColor: THREE.Color;
+  ambientColor: THREE.Color;
+};
+
+const WHITE = new THREE.Color(0xffffff);
+const BLACK = new THREE.Color(0x000000);
+const DEFAULT_SUN = new THREE.Color(1, 0.95, 0.82);
+const DEFAULT_AMBIENT = new THREE.Color(0.58, 0.61, 0.66);
+
+export class SkyCloudRenderer extends BaseRenderer {
+  private static sharedMaterial: THREE.ShaderMaterial | null = null;
+
+  private cloudGroup: THREE.Group;
+  private clouds: Set<THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>> = new Set();
+  private clock = new THREE.Clock();
+  private billboardTarget = new THREE.Vector3();
+  private tmpColor = new THREE.Color();
+
+  private globalState: SkyCloudGlobalState = {
+    cloudyFactor: 0.35,
+    speedMultiplier: 0.8,
+    wispyMultiplier: 1.0,
+    opacityMultiplier: 1.0,
+    sunDirection: new THREE.Vector3(0, 1, 0),
+    sunColor: DEFAULT_SUN.clone(),
+    ambientColor: DEFAULT_AMBIENT.clone(),
+  };
+
+  constructor(scene: THREE.Scene) {
+    super(scene);
+    this.cloudGroup = new THREE.Group();
+    this.cloudGroup.name = 'SkyCloudLayer';
+    this.scene.add(this.cloudGroup);
+  }
+
+  private getOrCreateMaterial(): THREE.ShaderMaterial {
+    if (SkyCloudRenderer.sharedMaterial) {
+      return SkyCloudRenderer.sharedMaterial;
+    }
+
+    const vertexShader = `
+      precision mediump float;
+
+      uniform float uTime;
+      uniform float uSpeedMultiplier;
+      uniform float uNoiseScale;
+      uniform float uNoiseStrength;
+      uniform float uWispyMultiplier;
+      uniform float uSeed;
+      uniform vec2 uMovement;
+
+      varying vec2 vUv;
+      varying vec2 vSampleCoord;
+      varying float vHeightNoise;
+
+      float hash(vec2 p) {
+        return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+      }
+
+      float noise(vec2 p) {
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+
+        float a = hash(i);
+        float b = hash(i + vec2(1.0, 0.0));
+        float c = hash(i + vec2(0.0, 1.0));
+        float d = hash(i + vec2(1.0, 1.0));
+
+        vec2 u = f * f * (3.0 - 2.0 * f);
+        return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+      }
+
+      float fbm(vec2 p) {
+        float value = 0.0;
+        float amplitude = 0.5;
+        for (int i = 0; i < 4; i++) {
+          value += amplitude * noise(p);
+          p *= 2.12;
+          amplitude *= 0.5;
+        }
+        return value;
+      }
+
+      void main() {
+        vUv = uv;
+        vec2 scaled = (uv - 0.5) * uNoiseScale;
+        vec2 flow = uMovement * uSpeedMultiplier * (uTime * 0.05);
+        vec2 sampleCoord = scaled + flow + vec2(uSeed, uSeed * 1.37);
+        vSampleCoord = sampleCoord;
+
+        float base = fbm(sampleCoord);
+        float detail = fbm(sampleCoord * 2.35);
+        float blend = clamp(uWispyMultiplier, 0.0, 2.0);
+        vHeightNoise = mix(base, detail, clamp(blend, 0.0, 1.0));
+
+        vec3 displaced = position;
+        displaced.z += (vHeightNoise - 0.5) * uNoiseStrength;
+
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
+      }
+    `;
+
+    const fragmentShader = `
+      precision mediump float;
+
+      uniform float uGlobalCloudiness;
+      uniform float uWispyMultiplier;
+      uniform float uOpacityMultiplier;
+      uniform float uOpacity;
+      uniform float uWispy;
+      uniform float uSoftness;
+      uniform float uNoiseStrength;
+      uniform vec3 uBaseColor;
+      uniform float uColorShift;
+      uniform vec2 uMovement;
+      uniform float uActivation;
+      uniform float uParallax;
+      uniform float uAspect;
+      uniform vec3 uSunDir;
+      uniform vec3 uSunColor;
+      uniform vec3 uAmbientColor;
+
+      varying vec2 vUv;
+      varying vec2 vSampleCoord;
+      varying float vHeightNoise;
+
+      float hash(vec2 p) {
+        return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+      }
+
+      float noise(vec2 p) {
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+
+        float a = hash(i);
+        float b = hash(i + vec2(1.0, 0.0));
+        float c = hash(i + vec2(0.0, 1.0));
+        float d = hash(i + vec2(1.0, 1.0));
+
+        vec2 u = f * f * (3.0 - 2.0 * f);
+        return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+      }
+
+      float fbm(vec2 p) {
+        float value = 0.0;
+        float amplitude = 0.5;
+        for (int i = 0; i < 4; i++) {
+          value += amplitude * noise(p);
+          p *= 2.12;
+          amplitude *= 0.5;
+        }
+        return value;
+      }
+
+      void main() {
+        vec2 centered = vUv - 0.5;
+        vec2 ellipseCoord = centered * vec2(uAspect, 1.0);
+        float ellipse = 1.0 - dot(ellipseCoord, ellipseCoord);
+
+        float detail = fbm(vSampleCoord);
+        float wispy = mix(uWispy, uWispy * uWispyMultiplier, 0.5);
+        float softness = max(0.05, uSoftness);
+        float mask = smoothstep(wispy - softness, wispy + softness, ellipse + (detail - 0.5) * uNoiseStrength);
+
+        float activation = smoothstep(uActivation - 0.12, uActivation + 0.02, uGlobalCloudiness);
+        float alpha = clamp(mask * activation * uOpacity * uOpacityMultiplier, 0.0, 1.0);
+
+        if (alpha <= 0.01) discard;
+
+        vec3 base = uBaseColor;
+        if (uColorShift > 0.0) {
+          base = mix(base, vec3(1.0), clamp(uColorShift, 0.0, 1.0));
+        } else if (uColorShift < 0.0) {
+          base = mix(base, vec3(0.0), clamp(-uColorShift, 0.0, 1.0));
+        }
+
+        vec3 sunDir = normalize(uSunDir);
+        float sunFactor = clamp(dot(normalize(vec3(0.0, 1.0, 0.25)), sunDir), 0.0, 1.0);
+        float edge = smoothstep(0.0, 0.7, ellipse);
+
+        vec3 color = mix(uAmbientColor, base, 0.65 + edge * 0.2);
+        color += (detail - 0.5) * 0.08;
+        color = mix(color, uSunColor, sunFactor * 0.25);
+
+        gl_FragColor = vec4(color, alpha);
+
+        #include <tonemapping_fragment>
+        #include <colorspace_fragment>
+      }
+    `;
+
+    SkyCloudRenderer.sharedMaterial = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      depthWrite: true,
+      depthTest: true,
+      alphaTest: 0.001,
+      side: THREE.DoubleSide,
+      blending: THREE.NormalBlending,
+      uniforms: {
+        uTime: { value: 0 },
+        uGlobalCloudiness: { value: 0.35 },
+        uSpeedMultiplier: { value: 1 },
+        uNoiseScale: { value: 2.2 },
+        uNoiseStrength: { value: 1.1 },
+        uWispyMultiplier: { value: 1 },
+        uOpacityMultiplier: { value: 1 },
+        uSeed: { value: 0 },
+        uMovement: { value: new THREE.Vector2() },
+        uSunDir: { value: new THREE.Vector3(0, 1, 0) },
+        uSunColor: { value: DEFAULT_SUN.clone() },
+        uAmbientColor: { value: DEFAULT_AMBIENT.clone() },
+        uOpacity: { value: 0.6 },
+        uWispy: { value: 0.6 },
+        uSoftness: { value: 0.22 },
+        uBaseColor: { value: new THREE.Color(1, 1, 1) },
+        uColorShift: { value: 0 },
+        uActivation: { value: 0.5 },
+        uParallax: { value: 1 },
+        uAspect: { value: 1 },
+      },
+    });
+
+    (SkyCloudRenderer.sharedMaterial as any).toneMapped = true;
+    return SkyCloudRenderer.sharedMaterial;
+  }
+
+  render(object: TSceneObject<SkyCloudObjectData>): THREE.Object3D {
+    const cloudData: SkyCloudObjectData = {
+      ...object.data,
+    };
+
+    const material = this.getOrCreateMaterial();
+    const geometry = new THREE.PlaneGeometry(1, 1, 24, 16);
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = `SkyCloud:${object.id}`;
+    mesh.matrixAutoUpdate = true;
+    mesh.frustumCulled = true;
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.renderOrder = 2000;
+
+    const altitudeOffset = cloudData.heightOffset ?? 0;
+    const basePosition = new THREE.Vector3(
+      object.coordinates.x,
+      object.coordinates.y,
+      object.coordinates.z,
+    );
+    mesh.position.set(
+      basePosition.x,
+      basePosition.y + altitudeOffset,
+      basePosition.z,
+    );
+    mesh.scale.set(cloudData.size * cloudData.aspectRatio, cloudData.size, 1);
+
+    const velocity = new THREE.Vector3(
+      Math.cos(cloudData.direction) * cloudData.speed,
+      0,
+      Math.sin(cloudData.direction) * cloudData.speed,
+    );
+
+    const internal: InternalCloudData = {
+      data: cloudData,
+      velocity,
+      boundsRadius: cloudData.boundsRadius,
+      basePosition,
+    };
+
+    mesh.userData.sky = internal;
+
+    mesh.onBeforeRender = (_renderer, _scene, camera, _geometry, mat) => {
+      const shader = mat as THREE.ShaderMaterial;
+      const info = mesh.userData.sky as InternalCloudData;
+      const data = info.data;
+
+      this.tmpColor.setHex(data.color);
+      if (data.colorShift > 0) {
+        this.tmpColor.lerp(WHITE, Math.min(1, data.colorShift));
+      } else if (data.colorShift < 0) {
+        this.tmpColor.lerp(BLACK, Math.min(1, -data.colorShift));
+      }
+
+      shader.uniforms.uBaseColor.value.copy(this.tmpColor);
+      shader.uniforms.uOpacity.value = Math.max(0, data.opacity * this.globalState.opacityMultiplier);
+      shader.uniforms.uWispy.value = data.wispiness;
+      shader.uniforms.uSoftness.value = data.softness;
+      shader.uniforms.uNoiseScale.value = data.noiseScale;
+      shader.uniforms.uNoiseStrength.value = data.noiseStrength;
+      shader.uniforms.uSeed.value = data.seed;
+      shader.uniforms.uMovement.value.set(
+        Math.cos(data.direction) * data.speed,
+        Math.sin(data.direction) * data.speed,
+      );
+      shader.uniforms.uActivation.value = data.activation;
+      shader.uniforms.uParallax.value = data.parallax;
+      shader.uniforms.uAspect.value = data.aspectRatio;
+
+      const basePosition = info.basePosition;
+      const heightOffset = data.heightOffset ?? 0;
+      mesh.position.set(
+        basePosition.x,
+        basePosition.y + heightOffset,
+        basePosition.z,
+      );
+
+      const cameraPosition = (camera as THREE.Camera).position as THREE.Vector3;
+      const parallaxValue = THREE.MathUtils.clamp(data.parallax ?? 1, 0.3, 2.0);
+      const parallaxStrength = THREE.MathUtils.clamp(parallaxValue - 1, -0.75, 0.75);
+      if (Math.abs(parallaxStrength) > 0.0001) {
+        const followStrength = 0.25;
+        mesh.position.x += cameraPosition.x * parallaxStrength * followStrength;
+        mesh.position.z += cameraPosition.z * parallaxStrength * followStrength;
+      }
+
+      this.billboardTarget.copy(cameraPosition);
+      this.billboardTarget.y = mesh.position.y;
+      mesh.lookAt(this.billboardTarget);
+      mesh.rotation.x = 0;
+      mesh.rotation.z = 0;
+    };
+
+    this.cloudGroup.add(mesh);
+    this.addMesh(object.id, mesh);
+    this.clouds.add(mesh);
+    return mesh;
+  }
+
+  update(_object: TSceneObject): void {
+    // Положення та анімацію коригуємо в updateSkyClouds
+  }
+
+  remove(id: string): void {
+    const mesh = this.meshes.get(id) as THREE.Mesh | undefined;
+    if (mesh) {
+      this.cloudGroup.remove(mesh);
+      this.clouds.delete(mesh as THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>);
+      mesh.geometry.dispose();
+    }
+    super.remove(id);
+  }
+
+  dispose(): void {
+    for (const mesh of this.clouds) {
+      this.cloudGroup.remove(mesh);
+      mesh.geometry.dispose();
+    }
+    this.clouds.clear();
+    this.scene.remove(this.cloudGroup);
+
+    if (SkyCloudRenderer.sharedMaterial) {
+      SkyCloudRenderer.sharedMaterial.dispose();
+      SkyCloudRenderer.sharedMaterial = null;
+    }
+
+    super.dispose();
+  }
+
+  updateSkyClouds(): void {
+    const delta = this.clock.getDelta();
+    const elapsed = this.clock.elapsedTime;
+    const material = SkyCloudRenderer.sharedMaterial;
+    if (material) {
+      material.uniforms.uTime.value = elapsed;
+      material.uniforms.uGlobalCloudiness.value = this.globalState.cloudyFactor;
+      material.uniforms.uSpeedMultiplier.value = this.globalState.speedMultiplier;
+      material.uniforms.uWispyMultiplier.value = this.globalState.wispyMultiplier;
+      material.uniforms.uOpacityMultiplier.value = this.globalState.opacityMultiplier;
+      material.uniforms.uSunDir.value.copy(this.globalState.sunDirection).normalize();
+      material.uniforms.uSunColor.value.copy(this.globalState.sunColor);
+      material.uniforms.uAmbientColor.value.copy(this.globalState.ambientColor);
+    }
+
+    for (const mesh of this.clouds) {
+      const info = mesh.userData.sky as InternalCloudData;
+      info.basePosition.x += info.velocity.x * delta * this.globalState.speedMultiplier;
+      info.basePosition.z += info.velocity.z * delta * this.globalState.speedMultiplier;
+
+      mesh.position.set(
+        info.basePosition.x,
+        info.basePosition.y + (info.data.heightOffset ?? 0),
+        info.basePosition.z,
+      );
+
+      const distance = Math.hypot(info.basePosition.x, info.basePosition.z);
+      if (distance > info.boundsRadius) {
+        const angle = Math.atan2(info.basePosition.z, info.basePosition.x) + Math.PI;
+        const radius = info.boundsRadius * (0.45 + Math.random() * 0.4);
+        info.basePosition.x = Math.cos(angle) * radius;
+        info.basePosition.z = Math.sin(angle) * radius;
+        mesh.position.set(
+          info.basePosition.x,
+          info.basePosition.y + (info.data.heightOffset ?? 0),
+          info.basePosition.z,
+        );
+      }
+    }
+  }
+
+  updateGlobalState(
+    state: SkyCloudRenderState & {
+      sunDirection: THREE.Vector3;
+      sunColor: THREE.Color;
+      ambientColor: THREE.Color;
+    },
+  ): void {
+    this.globalState.cloudyFactor = THREE.MathUtils.clamp(state.cloudyFactor, 0, 1);
+    this.globalState.speedMultiplier = state.speedMultiplier;
+    this.globalState.wispyMultiplier = state.wispyMultiplier;
+    this.globalState.opacityMultiplier = state.opacityMultiplier;
+    this.globalState.sunDirection.copy(state.sunDirection).normalize();
+    this.globalState.sunColor.copy(state.sunColor);
+    this.globalState.ambientColor.copy(state.ambientColor);
+
+    const material = SkyCloudRenderer.sharedMaterial;
+    if (material) {
+      material.uniforms.uGlobalCloudiness.value = this.globalState.cloudyFactor;
+      material.uniforms.uSpeedMultiplier.value = this.globalState.speedMultiplier;
+      material.uniforms.uWispyMultiplier.value = this.globalState.wispyMultiplier;
+      material.uniforms.uOpacityMultiplier.value = this.globalState.opacityMultiplier;
+      material.uniforms.uSunDir.value.copy(this.globalState.sunDirection);
+      material.uniforms.uSunColor.value.copy(this.globalState.sunColor);
+      material.uniforms.uAmbientColor.value.copy(this.globalState.ambientColor);
+    }
+  }
+}

--- a/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
+++ b/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
@@ -4,6 +4,7 @@ import { CameraController } from '@ui/screens/colony/scene/CameraController';
 import { RendererManager } from '@ui/screens/colony/scene/Scene3D/renderers/RendererManager';
 import { AreaSelectionRenderer } from '@ui/screens/colony/scene/AreaSelectionRenderer';
 import { IMapLogic } from '@interfaces/index';
+import { SkyCloudRenderState } from '@logic/systems/environment/environment.types';
 
 export interface RenderLoopOptions {
   maybeUpdateViewportOnMove: () => void;
@@ -75,6 +76,7 @@ export function useRenderLoop(
         }
       };
 
+      tryCall('sky-cloud', 'updateSkyClouds');
       tryCall('cloud', 'updateAllClouds');
       tryCall('smoke', 'updateAllSmoke');
       tryCall('fire', 'updateAllFire');
@@ -121,6 +123,39 @@ export function useRenderLoop(
         | { updateSunState?: (state: typeof sunState) => void }
         | undefined;
       sunRenderer?.updateSunState?.(sunState);
+
+      const skyState = environment.getSkyCloudRenderState?.();
+      if (skyState) {
+        const skyRenderer = rendererManagerRef.current?.renderers.get('sky-cloud') as
+          | {
+              updateGlobalState?: (
+                state: SkyCloudRenderState & {
+                  sunDirection: THREE.Vector3;
+                  sunColor: THREE.Color;
+                  ambientColor: THREE.Color;
+                }
+              ) => void;
+            }
+          | undefined;
+        skyRenderer?.updateGlobalState?.({
+          ...skyState,
+          sunDirection: new THREE.Vector3(
+            sunState.direction.x,
+            sunState.direction.y,
+            sunState.direction.z,
+          ),
+          sunColor: new THREE.Color(
+            sunState.sunColor.r,
+            sunState.sunColor.g,
+            sunState.sunColor.b,
+          ),
+          ambientColor: new THREE.Color(
+            sunState.backgroundColor.r,
+            sunState.backgroundColor.g,
+            sunState.backgroundColor.b,
+          ),
+        });
+      }
     }
 
     options.syncVisibleObjects();


### PR DESCRIPTION
## Summary
- extend the environment system with configurable sky cloud layers, weather cloudiness smoothing, and sun response
- add a dedicated SkyCloudRenderer with shader-driven billboards, movement, and parallax tied to global cloudiness
- hook the renderer into the manager and render loop and expose initial cloudy defaults in map config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e2cd20f08320aae643a2e234833d