### PR TITLE
Improve render loop performance and add HMR cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,13 +16,18 @@ function App() {
   useEffect(() => {
     game.initGame();
     setIsGameInitialized(true);
-    
+
     // Експортуємо debug функції для браузера
     (window as any).debugGame = {
       storage: (buildingId?: string) => game.debugBuildingStorage(buildingId),
       game: game
     };
     console.log('[App] Debug functions available: window.debugGame.storage(), window.debugGame.game');
+
+    return () => {
+      game.stopTicks();
+      delete (window as any).debugGame;
+    };
   }, [game]);
 
   const handleStartGame = () => {

--- a/src/logic/core/game/GameContainer.ts
+++ b/src/logic/core/game/GameContainer.ts
@@ -35,10 +35,10 @@ export interface ServiceTypeMap {
 }
 
 export class GameContainer {
-  private static instance: GameContainer;
+  private static instance: GameContainer | null = null;
   private factories = new Map<ServiceKey, () => any>();
   private instances = new Map<ServiceKey, any>();
-  
+
   static getInstance(): GameContainer {
     if (!GameContainer.instance) {
       GameContainer.instance = new GameContainer();
@@ -101,6 +101,24 @@ export class GameContainer {
    */
   clear(): void {
     this.instances.clear();
+  }
+
+  /**
+   * Повністю скидає контейнер сервісів (для HMR/тестів)
+   */
+  private dispose(): void {
+    this.instances.clear();
+    this.factories.clear();
+  }
+
+  /**
+   * Скидає singleton інстанс контейнера
+   */
+  static resetInstance(): void {
+    if (GameContainer.instance) {
+      GameContainer.instance.dispose();
+      GameContainer.instance = null;
+    }
   }
   
   /**

--- a/src/logic/core/game/game.ts
+++ b/src/logic/core/game/game.ts
@@ -19,7 +19,7 @@ import { GraphicsSettingsManager } from '@systems/graphics';
 
 
 export class Game {
-  private static instance: Game;
+  private static instance: Game | null = null;
   private container: GameContainer;
   
   // Основні менеджери  
@@ -197,6 +197,18 @@ export class Game {
       Game.instance = new Game();
     }
     return Game.instance;
+  }
+
+  private destroy(): void {
+    this.stopTicks();
+  }
+
+  public static destroyInstance(): void {
+    if (Game.instance) {
+      Game.instance.destroy();
+      Game.instance = null;
+      GameContainer.resetInstance();
+    }
   }
   
   /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,26 @@
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { Game } from '@core/game/game';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const container = document.getElementById('root');
 
-    <App />
-)
+if (!container) {
+  throw new Error('Root element with id "root" not found');
+}
+
+const root = ReactDOM.createRoot(container);
+
+const render = () => {
+  root.render(<App />);
+};
+
+render();
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+  import.meta.hot.dispose(() => {
+    root.unmount();
+    Game.destroyInstance();
+  });
+}

--- a/src/ui/screens/colony/scene/CameraController/CameraController.ts
+++ b/src/ui/screens/colony/scene/CameraController/CameraController.ts
@@ -43,11 +43,12 @@ export class CameraController {
   private targetPosition = new THREE.Vector3()
   private targetLookAt = new THREE.Vector3()
   private interpolationSpeed = 0.1 // Швидкість інтерполяції (0.1 = плавно, 1.0 = миттєво)
-  
+
   // Camera pinning orbit controls
   private pinnedDistance = 10 // Відстань до закріпленого об'єкта
   private pinnedAngleX = 0 // Вертикальний кут (нахил)
   private pinnedAngleY = 0 // Горизонтальний кут (обертання)
+  private pinnedScratch = new THREE.Vector3()
 
   constructor(
     camera: THREE.PerspectiveCamera, 
@@ -490,15 +491,17 @@ export class CameraController {
     }
   }
   
-  public getPinnedCameraPosition(): THREE.Vector3 {
-    if (!this.isPinned) return this.camera.position.clone()
-    
+  public getPinnedCameraPosition(target: THREE.Vector3 = this.pinnedScratch): THREE.Vector3 {
+    if (!this.isPinned) {
+      return target.copy(this.camera.position)
+    }
+
     // Розраховуємо позицію камери на основі кутів та відстані
     const x = this.target.x + this.pinnedDistance * Math.sin(this.pinnedAngleY) * Math.cos(this.pinnedAngleX)
     const y = this.target.y + this.pinnedDistance * Math.sin(this.pinnedAngleX)
     const z = this.target.z + this.pinnedDistance * Math.cos(this.pinnedAngleY) * Math.cos(this.pinnedAngleX)
-    
-    return new THREE.Vector3(x, y, z)
+
+    return target.set(x, y, z)
   }
 
   // Cleanup

--- a/src/ui/screens/colony/scene/Scene3D/renderers/environment/SkyCloudRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/environment/SkyCloudRenderer.ts
@@ -291,6 +291,8 @@ export class SkyCloudRenderer extends BaseRenderer {
 
     const info: InternalCloudData = {
       data: { ...instance.data },
+      velocity: new THREE.Vector3(),
+      boundsRadius: Math.max(instance.data.size, instance.data.size * instance.data.aspectRatio),
       basePosition: new THREE.Vector3(instance.position.x, instance.position.y, instance.position.z),
     };
 

--- a/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
+++ b/src/ui/screens/colony/scene/hooks/useRenderLoop.ts
@@ -26,6 +26,41 @@ export function useRenderLoop(
   const [fps, setFps] = useState(0);
   const frameCountRef = useRef(0);
   const lastTimeRef = useRef(performance.now());
+  const pinnedLookAtRef = useRef(new THREE.Vector3());
+  const pinnedCameraPosRef = useRef(new THREE.Vector3());
+  const sunDirectionRef = useRef(new THREE.Vector3());
+  const sunColorRef = useRef(new THREE.Color());
+  const ambientColorRef = useRef(new THREE.Color());
+  const skyGlobalStateRef = useRef<
+    (SkyCloudRenderState & {
+      sunDirection: THREE.Vector3;
+      sunColor: THREE.Color;
+      ambientColor: THREE.Color;
+    })
+  >({
+    cloudyFactor: 0,
+    speedMultiplier: 1,
+    wispyMultiplier: 1,
+    opacityMultiplier: 1,
+    sunDirection: sunDirectionRef.current,
+    sunColor: sunColorRef.current,
+    ambientColor: ambientColorRef.current,
+  });
+
+  const callRendererMethod = useCallback(
+    (key: string, fn: string) => {
+      const manager = rendererManagerRef.current;
+      if (!manager) return;
+      const rendererEntry = manager.renderers.get(key) as
+        | { [method: string]: (() => void) | undefined }
+        | undefined;
+      const method = rendererEntry?.[fn];
+      if (typeof method === 'function') {
+        method.call(rendererEntry);
+      }
+    },
+    [rendererManagerRef]
+  );
 
   const tick = useCallback(() => {
     rafRef.current = requestAnimationFrame(tick);
@@ -53,38 +88,28 @@ export function useRenderLoop(
       if (pinnedObjectId) {
         const pinnedObject = mapLogicRef.current?.scene.getObjectById(pinnedObjectId);
         if (pinnedObject) {
-          const targetLookAt = new THREE.Vector3(
+          const targetLookAt = pinnedLookAtRef.current;
+          targetLookAt.set(
             pinnedObject.coordinates.x,
             pinnedObject.coordinates.y,
             pinnedObject.coordinates.z
           );
 
-          const targetPos = controller.getPinnedCameraPosition();
+          const targetPos = controller.getPinnedCameraPosition(pinnedCameraPosRef.current);
           controller.setTargetPosition(targetPos, targetLookAt);
           controller.updateSmoothMovement();
         }
       }
     }
 
-    const rm = rendererManagerRef.current;
-    if (rm) {
-      const tryCall = (key: string, fn: string) => {
-        const r = rm.renderers.get(key);
-        if (r && fn in r) {
-          const rendererAny = r as unknown as { [key: string]: () => void };
-          rendererAny[fn]();
-        }
-      };
-
-      tryCall('sky-cloud', 'updateSkyClouds');
-      tryCall('cloud', 'updateAllClouds');
-      tryCall('smoke', 'updateAllSmoke');
-      tryCall('fire', 'updateAllFire');
-      tryCall('explosion', 'updateAllExplosions');
-      tryCall('electric-arc', 'updateAllArcs');
-      tryCall('aurora', 'updateEnvironmentEffects');
-      tryCall('rover', 'updateDustTrails');
-    }
+    callRendererMethod('sky-cloud', 'updateSkyClouds');
+    callRendererMethod('cloud', 'updateAllClouds');
+    callRendererMethod('smoke', 'updateAllSmoke');
+    callRendererMethod('fire', 'updateAllFire');
+    callRendererMethod('explosion', 'updateAllExplosions');
+    callRendererMethod('electric-arc', 'updateAllArcs');
+    callRendererMethod('aurora', 'updateEnvironmentEffects');
+    callRendererMethod('rover', 'updateDustTrails');
 
     const lights = (scene as THREE.Scene & {
       __lights__?: { ambient: THREE.AmbientLight; dir: THREE.DirectionalLight };
@@ -108,6 +133,27 @@ export function useRenderLoop(
         sunState.haloColor.r,
         sunState.haloColor.g,
         sunState.haloColor.b,
+      );
+
+      const sunDirection = sunDirectionRef.current;
+      sunDirection.set(
+        sunState.direction.x,
+        sunState.direction.y,
+        sunState.direction.z,
+      );
+
+      const sunColor = sunColorRef.current;
+      sunColor.setRGB(
+        sunState.sunColor.r,
+        sunState.sunColor.g,
+        sunState.sunColor.b,
+      );
+
+      const ambientColor = ambientColorRef.current;
+      ambientColor.setRGB(
+        sunState.backgroundColor.r,
+        sunState.backgroundColor.g,
+        sunState.backgroundColor.b,
       );
 
       // Оновлюємо колір фону в залежності від пори доби
@@ -141,24 +187,12 @@ export function useRenderLoop(
       if (skyRenderer) {
         const skyState = environment.getSkyCloudRenderState?.();
         if (skyState) {
-          skyRenderer.updateGlobalState?.({
-            ...skyState,
-            sunDirection: new THREE.Vector3(
-              sunState.direction.x,
-              sunState.direction.y,
-              sunState.direction.z,
-            ),
-            sunColor: new THREE.Color(
-              sunState.sunColor.r,
-              sunState.sunColor.g,
-              sunState.sunColor.b,
-            ),
-            ambientColor: new THREE.Color(
-              sunState.backgroundColor.r,
-              sunState.backgroundColor.g,
-              sunState.backgroundColor.b,
-            ),
-          });
+          const skyGlobalState = skyGlobalStateRef.current;
+          skyGlobalState.cloudyFactor = skyState.cloudyFactor;
+          skyGlobalState.speedMultiplier = skyState.speedMultiplier;
+          skyGlobalState.wispyMultiplier = skyState.wispyMultiplier;
+          skyGlobalState.opacityMultiplier = skyState.opacityMultiplier;
+          skyRenderer.updateGlobalState?.(skyGlobalState);
         }
 
         const skyInstances = environment.getSkyCloudInstances?.();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add a destroy path for the Game singleton and reset the DI container so hot reloads dispose old state, wiring cleanup into the app entrypoint
- optimize the render loop by reusing vectors/colors and cached callbacks, plus reuse camera scratch vectors and provide default cloud metadata
- declare Vite client types so TypeScript recognizes the HMR APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d435907a608320b868bbb76f12f08b