### PR TITLE
Disable sky clouds, simplify shadows, and add antialiasing toggle

### DIFF
--- a/docs/structure/ui/scene-3d-system.md
+++ b/docs/structure/ui/scene-3d-system.md
@@ -14,7 +14,7 @@
 - `RockRenderer.ts` — рендерер каменюків та ресурсів
 - `BiomassRenderer.ts` — рендерер біомаси та рослин
 - `SelectionRenderer.ts` — рендерер вибору об'єктів
-- `CloudRenderer.ts` — рендерер хмар та атмосферних ефектів
+- `DustCloudRenderer.ts` — рендерер пилових хмар та атмосферних ефектів
 - `SmokeRenderer.ts` — рендерер диму та частинок
 - `FireRenderer.ts` — рендерер вогню та ефектів
 - `ExplosionRenderer.ts` — рендерер вибухів

--- a/src/logic/systems/environment/EnvironmentLogic.ts
+++ b/src/logic/systems/environment/EnvironmentLogic.ts
@@ -66,6 +66,7 @@ const DEFAULT_CONFIG: EnvironmentConfig = {
     particleCount: 200,
     color: 0xd2b46c,
   },
+  skyCloudsEnabled: false,
   skyClouds: {
     initialCloudyFactor: 0.35,
     smoothingSeconds: 25,
@@ -154,6 +155,7 @@ type InternalSkyCloud = {
 export class EnvironmentLogic {
   private readonly scene: SceneLogic;
   private config: EnvironmentConfig;
+  private readonly skyCloudsEnabled: boolean;
 
   private activeEffects: Map<string, IEnvironmentEffect> = new Map();
   private lastUpdateTime = 0;
@@ -199,6 +201,7 @@ export class EnvironmentLogic {
   constructor(scene: SceneLogic, config?: Partial<EnvironmentConfig>) {
     this.scene = scene;
     this.config = this.mergeConfig(DEFAULT_CONFIG, config);
+    this.skyCloudsEnabled = !!this.config.skyCloudsEnabled;
 
     this.gameMinutesPerRealSecond = 24 / this.config.time.dayLengthMinutes;
 
@@ -212,19 +215,24 @@ export class EnvironmentLogic {
     this.weather.nextWindChangeMinute =
       this.time.totalMinutes + windRange.changeIntervalHours * 60;
 
-    const initialCloudiness =
-      this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0;
+    const initialCloudiness = this.skyCloudsEnabled
+      ? this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0
+      : 0;
     const clampedCloudiness = this.clamp(initialCloudiness, 0, 1);
     this.weather.cloudyFactor = clampedCloudiness;
     this.weather.cloudyTarget = clampedCloudiness;
     this.cloudyFactor = clampedCloudiness;
     this.cloudyTarget = clampedCloudiness;
 
-    this.skyCloudTotalCap = this.config.skyClouds.layers.reduce(
-      (sum, layer) => sum + Math.max(0, layer.maxCount),
-      0,
-    );
-    this.scheduleNextCloudinessUpdate();
+    if (this.skyCloudsEnabled) {
+      this.skyCloudTotalCap = this.config.skyClouds.layers.reduce(
+        (sum, layer) => sum + Math.max(0, layer.maxCount),
+        0,
+      );
+      this.scheduleNextCloudinessUpdate();
+    } else {
+      this.skyCloudTotalCap = 0;
+    }
     this.state = this.buildEnvironmentState();
   }
 
@@ -251,14 +259,20 @@ export class EnvironmentLogic {
       this.time.totalMinutes + windRange.changeIntervalHours * 60;
 
     const startCloudiness =
-      this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0;
+      this.skyCloudsEnabled
+        ? this.config.skyClouds.initialCloudyFactor ?? this.config.weather.cloudyFactor ?? 0
+        : 0;
     const clampedCloudiness = this.clamp(startCloudiness, 0, 1);
     this.weather.cloudyFactor = clampedCloudiness;
     this.weather.cloudyTarget = clampedCloudiness;
     this.cloudyFactor = clampedCloudiness;
     this.cloudyTarget = clampedCloudiness;
-    this.scheduleNextCloudinessUpdate();
-    this.seedSkyClouds();
+    if (this.skyCloudsEnabled) {
+      this.scheduleNextCloudinessUpdate();
+      this.seedSkyClouds();
+    } else {
+      this.clearSkyClouds();
+    }
     this.generateInitialDustClouds();
     this.state = this.buildEnvironmentState();
   }
@@ -274,9 +288,16 @@ export class EnvironmentLogic {
     this.advanceTime(deltaTimeSeconds);
     this.updateWeather(deltaTimeSeconds);
     this.updateDustClouds(deltaTimeSeconds);
-    this.updateCloudinessCycle();
-    this.updateCloudyFactor(deltaTimeSeconds);
-    this.updateSkyCloudLifecycle(deltaTimeSeconds);
+    if (this.skyCloudsEnabled) {
+      this.updateCloudinessCycle();
+      this.updateCloudyFactor(deltaTimeSeconds);
+      this.updateSkyCloudLifecycle(deltaTimeSeconds);
+    } else {
+      this.cloudyFactor = 0;
+      this.cloudyTarget = 0;
+      this.weather.cloudyFactor = 0;
+      this.weather.cloudyTarget = 0;
+    }
 
     const now = Date.now();
     if (now - this.lastUpdateTime >= this.config.updateInterval) {
@@ -342,6 +363,14 @@ export class EnvironmentLogic {
    * Параметри для шейдера небесних хмар
    */
   getSkyCloudRenderState(): SkyCloudRenderState {
+    if (!this.skyCloudsEnabled) {
+      return {
+        cloudyFactor: 0,
+        speedMultiplier: 0,
+        wispyMultiplier: 0,
+        opacityMultiplier: 0,
+      };
+    }
     const skyConfig = this.config.skyClouds;
     const speedMultiplier = this.getCurrentCloudSpeedMultiplier();
 
@@ -355,6 +384,9 @@ export class EnvironmentLogic {
 
 
   getSkyCloudInstances(): SkyCloudInstance[] {
+    if (!this.skyCloudsEnabled) {
+      return [];
+    }
     if (this.skyCloudSnapshotDirty) {
       this.skyCloudSnapshot = Array.from(this.skyCloudInstances.values()).map((cloud) => ({
         id: cloud.id,
@@ -380,6 +412,13 @@ export class EnvironmentLogic {
    * Встановити нову цільову хмарність (0..1)
    */
   setCloudyFactor(value: number): void {
+    if (!this.skyCloudsEnabled) {
+      this.cloudyTarget = 0;
+      this.weather.cloudyTarget = 0;
+      this.cloudyFactor = 0;
+      this.weather.cloudyFactor = 0;
+      return;
+    }
     const clamped = this.clamp(value, 0, 1);
     this.cloudyTarget = clamped;
     this.weather.cloudyTarget = clamped;
@@ -439,8 +478,12 @@ export class EnvironmentLogic {
     }
 
     this.weather.temperature = this.calculateTemperature();
-    this.scheduleNextCloudinessUpdate();
-    this.seedSkyClouds();
+    if (this.skyCloudsEnabled) {
+      this.scheduleNextCloudinessUpdate();
+      this.seedSkyClouds();
+    } else {
+      this.clearSkyClouds();
+    }
     this.state = this.buildEnvironmentState();
   }
 
@@ -688,6 +731,11 @@ export class EnvironmentLogic {
   }
 
   private updateCloudyFactor(deltaTimeSeconds: number): void {
+    if (!this.skyCloudsEnabled) {
+      this.cloudyFactor = 0;
+      this.weather.cloudyFactor = 0;
+      return;
+    }
     const diff = this.cloudyTarget - this.cloudyFactor;
     if (Math.abs(diff) < 0.0001) {
       this.cloudyFactor = this.cloudyTarget;
@@ -832,6 +880,10 @@ export class EnvironmentLogic {
   }
 
   private seedSkyClouds(): void {
+    if (!this.skyCloudsEnabled) {
+      this.clearSkyClouds();
+      return;
+    }
     const cfg = this.config.skyClouds;
     if (!cfg) return;
 
@@ -852,6 +904,7 @@ export class EnvironmentLogic {
   }
 
   private spawnSkyCloudForDemand(): void {
+    if (!this.skyCloudsEnabled) return;
     const cfg = this.config.skyClouds;
     if (!cfg || this.cloudyFactor <= 0) return;
 
@@ -892,6 +945,9 @@ export class EnvironmentLogic {
   }
 
   private spawnSkyCloud(layer: SkyCloudLayerConfig, progressNormalized = 0): boolean {
+    if (!this.skyCloudsEnabled) {
+      return false;
+    }
     if (this.skyCloudInstances.size >= this.skyCloudTotalCap) {
       return false;
     }
@@ -1063,6 +1119,9 @@ export class EnvironmentLogic {
   }
 
   private updateSkyCloudLifecycle(deltaTimeSeconds: number): void {
+    if (!this.skyCloudsEnabled) {
+      return;
+    }
     const cfg = this.config.skyClouds;
     if (!cfg) return;
 
@@ -1132,6 +1191,9 @@ export class EnvironmentLogic {
   }
 
   private updateCloudinessCycle(): void {
+    if (!this.skyCloudsEnabled) {
+      return;
+    }
     if (this.time.totalMinutes < this.nextCloudinessUpdateMinute) {
       return;
     }
@@ -1147,12 +1209,19 @@ export class EnvironmentLogic {
   }
 
   private scheduleNextCloudinessUpdate(): void {
+    if (!this.skyCloudsEnabled) {
+      this.nextCloudinessUpdateMinute = Number.POSITIVE_INFINITY;
+      return;
+    }
     const interval = this.config.skyClouds.cloudinessUpdateIntervalMinutes ?? 60;
     const minutes = Math.max(1, interval);
     this.nextCloudinessUpdateMinute = this.time.totalMinutes + minutes;
   }
 
   private getCurrentCloudSpeedMultiplier(): number {
+    if (!this.skyCloudsEnabled) {
+      return 0;
+    }
     const skyConfig = this.config.skyClouds;
     const windRange = this.config.weather.windSpeed;
     const windSpan = Math.max(0.0001, windRange.max - windRange.min);

--- a/src/logic/systems/environment/environment.types.ts
+++ b/src/logic/systems/environment/environment.types.ts
@@ -246,6 +246,7 @@ export interface EnvironmentConfig {
   dustClouds: DustCloudConfig;
 
   // Небесні хмари
+  skyCloudsEnabled?: boolean;
   skyClouds: SkyCloudConfig;
 
   // Параметри вигляду сонця

--- a/src/logic/systems/graphics/GraphicsSettingsManager.ts
+++ b/src/logic/systems/graphics/GraphicsSettingsManager.ts
@@ -1,18 +1,21 @@
 import type { SaveLoadManager } from '@save-load/save-load.types';
 
-export type ShadowQuality = 'detailed' | 'pseudo' | 'none';
+export type ShadowQuality = 'detailed' | 'none';
 export type ParticleQuality = 'high' | 'low';
+export type AntialiasingMode = 'msaa' | 'off';
 
 export interface GraphicsSettingsState {
   shadows: ShadowQuality;
   particles: ParticleQuality;
   droneDustTrails: boolean;
+  antialiasing: AntialiasingMode;
 }
 
 const DEFAULT_SETTINGS: GraphicsSettingsState = {
-  shadows: 'pseudo',
+  shadows: 'none',
   particles: 'high',
   droneDustTrails: true,
+  antialiasing: 'msaa',
 };
 
 type Listener = (state: GraphicsSettingsState) => void;
@@ -37,12 +40,19 @@ export class GraphicsSettingsManager implements SaveLoadManager {
     this.emit();
   }
 
+  public setAntialiasing(mode: AntialiasingMode): void {
+    if (this.state.antialiasing === mode) return;
+    this.state = { ...this.state, antialiasing: mode };
+    this.emit();
+  }
+
   public update(partial: Partial<GraphicsSettingsState>): void {
     const next: GraphicsSettingsState = { ...this.state, ...partial };
     if (
       next.shadows === this.state.shadows &&
       next.particles === this.state.particles &&
-      next.droneDustTrails === this.state.droneDustTrails
+      next.droneDustTrails === this.state.droneDustTrails &&
+      next.antialiasing === this.state.antialiasing
     ) {
       return;
     }
@@ -79,6 +89,7 @@ export class GraphicsSettingsManager implements SaveLoadManager {
       shadows: this.parseShadowQuality((data as GraphicsSettingsState).shadows),
       particles: this.parseParticleQuality((data as GraphicsSettingsState).particles),
       droneDustTrails: this.parseDroneDustTrails((data as GraphicsSettingsState).droneDustTrails),
+      antialiasing: this.parseAntialiasing((data as GraphicsSettingsState).antialiasing),
     };
 
     this.state = next;
@@ -91,7 +102,7 @@ export class GraphicsSettingsManager implements SaveLoadManager {
   }
 
   private parseShadowQuality(value: unknown): ShadowQuality {
-    if (value === 'detailed' || value === 'pseudo' || value === 'none') {
+    if (value === 'detailed' || value === 'none') {
       return value;
     }
     return DEFAULT_SETTINGS.shadows;
@@ -115,5 +126,12 @@ export class GraphicsSettingsManager implements SaveLoadManager {
       return value;
     }
     return DEFAULT_SETTINGS.droneDustTrails;
+  }
+
+  private parseAntialiasing(value: unknown): AntialiasingMode {
+    if (value === 'msaa' || value === 'off') {
+      return value;
+    }
+    return DEFAULT_SETTINGS.antialiasing;
   }
 }

--- a/src/logic/systems/graphics/index.ts
+++ b/src/logic/systems/graphics/index.ts
@@ -1,2 +1,7 @@
 export { GraphicsSettingsManager } from './GraphicsSettingsManager';
-export type { GraphicsSettingsState, ParticleQuality, ShadowQuality } from './GraphicsSettingsManager';
+export type {
+  GraphicsSettingsState,
+  ParticleQuality,
+  ShadowQuality,
+  AntialiasingMode,
+} from './GraphicsSettingsManager';

--- a/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
+++ b/src/ui/screens/colony/scene/Scene3D/Scene3D.tsx
@@ -11,7 +11,7 @@ import { VerticalMenuWithContext } from '../components/VerticalMenuWithContext';
 import { DragSelection } from '../DragSelection';
 import PathfindingDebug from '../debug/PathfindingDebug';
 import { createUiLogicBridge } from '@ui/logic/UiLogicBridge';
-import { useSceneCore, useScreenRaycaster } from '../hooks/useSceneCore';
+import { useSceneCore, useScreenRaycaster, getPixelRatioForMode } from '../hooks/useSceneCore';
 import { useSceneManagers } from '../hooks/useSceneManagers';
 import { useCameraController, useCameraViewportSync } from '../hooks/useCameraSystems';
 import { ensureAreaSelectionRenderer, useTerrainStreaming } from '../hooks/useTerrainStreaming';
@@ -31,8 +31,9 @@ interface Scene3DProps {
 
 const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic, game }) => {
   const mountRef = useRef<HTMLDivElement>(null);
+  const [graphicsSettingsState, setGraphicsSettingsState] = useState(game.graphicsSettings.getState());
 
-  const { scene, camera, renderer } = useSceneCore();
+  const { scene, camera, renderer } = useSceneCore(graphicsSettingsState.antialiasing);
   const loadingManagerRef = useRef<SceneLoadingManager | null>(null);
   if (!loadingManagerRef.current) {
     loadingManagerRef.current = new SceneLoadingManager();
@@ -40,7 +41,6 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
   const loadingManager = loadingManagerRef.current;
   const loadingSnapshot = useSceneLoadingSnapshot(loadingManager);
   const [isSceneReady, setIsSceneReady] = useState(false);
-  const [graphicsSettingsState, setGraphicsSettingsState] = useState(game.graphicsSettings.getState());
   const manualPending = Math.max(0, loadingSnapshot.manualTotal - loadingSnapshot.manualCompleted);
   const loadingMessage = loadingSnapshot.lastUrl
     ? `Завантаження: ${loadingSnapshot.lastUrl.split('/').pop()}`
@@ -202,6 +202,7 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
     const onResize = () => {
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
+      renderer.setPixelRatio(getPixelRatioForMode(graphicsSettingsState.antialiasing));
       renderer.setSize(window.innerWidth, window.innerHeight);
       updateViewport();
       ensureTargetOnTerrain();
@@ -222,7 +223,18 @@ const Scene3D: React.FC<Scene3DProps> = ({ onShowMainMenu, mapLogic: appMapLogic
         mountRef.current.removeChild(renderer.domElement);
       }
     };
-  }, [camera, controller, ensureTargetOnTerrain, renderer, updateViewport]);
+  }, [
+    camera,
+    controller,
+    ensureTargetOnTerrain,
+    renderer,
+    updateViewport,
+    graphicsSettingsState.antialiasing,
+  ]);
+
+  useEffect(() => {
+    renderer.setPixelRatio(getPixelRatioForMode(graphicsSettingsState.antialiasing));
+  }, [graphicsSettingsState.antialiasing, renderer]);
 
   return (
     <div ref={mountRef} style={{ width: '100%', height: '100vh', position: 'relative', overflow: 'hidden' }}>

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BiomassRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BiomassRenderer.ts
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { BaseRenderer } from './BaseRenderer'
 import { TSceneObject } from '@logic/systems/scene/scene.types'
 import { MapLogic } from '@logic/systems/map/map-logic'
-import { applyBakedShadow, removeBakedShadow } from './utils/bakedShadows'
+import { removeBakedShadow } from './utils/bakedShadows'
 import type { ShadowQuality } from '@systems/graphics'
 
 interface BiomassData {
@@ -41,7 +41,7 @@ export class BiomassRenderer extends BaseRenderer {
   private readonly shadowSize = new THREE.Vector3();
   private readonly shadowCenter = new THREE.Vector3();
 
-  private shadowMode: ShadowQuality = 'pseudo';
+  private shadowMode: ShadowQuality = 'none';
   private shadowConfigs = new Map<string, ShadowOptions>();
 
   private computeShadowFootprint(source: THREE.Object3D) {
@@ -63,28 +63,15 @@ export class BiomassRenderer extends BaseRenderer {
   private applyShadow(
     instanceId: string,
     target: THREE.Object3D,
-    footprint: { width: number; depth: number; minY: number; centerX: number; centerZ: number },
+    _footprint: { width: number; depth: number; minY: number; centerX: number; centerZ: number },
     options?: ShadowOptions
   ) {
+    void _footprint;
     this.shadowConfigs.set(instanceId, options ?? {});
 
     const enableDynamic = this.shadowMode === 'detailed';
     this.setShadowFlags(target, enableDynamic);
     removeBakedShadow(target);
-
-    if (!enableDynamic && this.shadowMode === 'pseudo') {
-      applyBakedShadow(target, {
-        width: footprint.width,
-        depth: footprint.depth,
-        minY: footprint.minY,
-        centerX: footprint.centerX,
-        centerZ: footprint.centerZ,
-        intensity: options?.intensity ?? 0.4,
-        softness: options?.softness ?? 1.3,
-        minSize: options?.minSize ?? 0.35,
-        offset: options?.offset,
-      });
-    }
   }
 
   private setShadowFlags(target: THREE.Object3D, enabled: boolean) {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/BuildingRenderer.ts
@@ -9,7 +9,7 @@ import { ResourceRequest } from '@logic/modules/resources/resource-types';
 import { HudCanvasBuilder, BUILDING_HUD_STYLE } from './hud/HudCanvasBuilder';
 import type { HudCanvasRequest, HudResourceEntry } from './hud/HudCanvasBuilder';
 import { clampScaleByWidth, computeScreenSpaceScale } from './hud/hudMath';
-import { applyBakedShadow, removeBakedShadow } from './utils/bakedShadows';
+import { removeBakedShadow } from './utils/bakedShadows';
 import type { ShadowQuality } from '@systems/graphics';
 
 // ---------- TMP ----------
@@ -18,10 +18,6 @@ const _worldScale = new THREE.Vector3();
 const _worldPos = new THREE.Vector3();
 const _localOffset = new THREE.Vector3();
 const _viewDir = new THREE.Vector3();
-const _shadowSize = new THREE.Vector3();
-const _shadowCenter = new THREE.Vector3();
-const _shadowBox = new THREE.Box3();
-
 // ---------- Screen-space таргети ----------
 // Позиціонування у світі
 const HUD_WORLD_Y_OFFSET_FALLBACK = 0.6;
@@ -47,7 +43,7 @@ export class BuildingRenderer extends BaseRenderer {
 
   private uiLogicBridge: UiLogicBridge | null = null; // Bridge to logic for storage info
 
-  private shadowMode: ShadowQuality = 'pseudo';
+  private shadowMode: ShadowQuality = 'none';
   private shadowSources = new WeakMap<THREE.Object3D, { source: THREE.Object3D; options?: ShadowOptions }>();
 
   constructor(scene: THREE.Scene, renderer?: THREE.WebGLRenderer, loadingManager?: THREE.LoadingManager) {
@@ -66,29 +62,6 @@ export class BuildingRenderer extends BaseRenderer {
 
     this.loader = new GLTFLoader(loadingManager ?? undefined);
     this.hudBuilder = new HudCanvasBuilder(renderer, this.hudStyle);
-  }
-
-  private applyShadowFromSource(
-    container: THREE.Object3D,
-    source: THREE.Object3D,
-    options?: ShadowOptions
-  ): void {
-    source.updateWorldMatrix(true, true);
-    _shadowBox.setFromObject(source);
-    _shadowBox.getSize(_shadowSize);
-    _shadowBox.getCenter(_shadowCenter);
-
-    applyBakedShadow(container, {
-      width: _shadowSize.x,
-      depth: _shadowSize.z,
-      minY: _shadowBox.min.y,
-      centerX: _shadowCenter.x,
-      centerZ: _shadowCenter.z,
-      intensity: options?.intensity,
-      softness: options?.softness,
-      minSize: options?.minSize,
-      offset: options?.offset,
-    });
   }
 
   public setShadowMode(mode: ShadowQuality): void {
@@ -120,10 +93,6 @@ export class BuildingRenderer extends BaseRenderer {
     const enableDynamic = this.shadowMode === 'detailed';
     this.setContainerShadowFlags(container, enableDynamic);
     removeBakedShadow(container);
-
-    if (!enableDynamic && this.shadowMode === 'pseudo') {
-      this.applyShadowFromSource(container, source, options);
-    }
   }
 
   private setContainerShadowFlags(container: THREE.Object3D, enabled: boolean): void {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/DustCloudRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/DustCloudRenderer.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { BaseRenderer } from './BaseRenderer';
 import { TSceneObject } from '@logic/systems/scene/scene.types';
 
-export interface CloudData {
+export interface DustCloudData {
   color?: number;        // базовий колір хмари
   size?: number;         // "візуальний" розмір частинки (у пікселях, базово ~72)
   density?: number;      // не використовується тут (залишив на майбутнє)
@@ -14,7 +14,7 @@ export interface CloudData {
 const _tmpV2 = new THREE.Vector2(); // для uSizeAtten
 
 
-export class CloudRenderer extends BaseRenderer {
+export class DustCloudRenderer extends BaseRenderer {
   private dustParticles: THREE.Points[] = [];
   private cloudGroup: THREE.Group;
   private clock: THREE.Clock;
@@ -28,12 +28,12 @@ export class CloudRenderer extends BaseRenderer {
     this.cloudGroup.name = 'CloudGroup';
     this.clock = new THREE.Clock();
     this.scene.add(this.cloudGroup);
-            // CloudRenderer створено
+    // DustCloudRenderer створено
   }
 
   // ===== Shared material =====
   private getOrCreateMaterial(): THREE.ShaderMaterial {
-    if (CloudRenderer.sharedMaterial) return CloudRenderer.sharedMaterial;
+    if (DustCloudRenderer.sharedMaterial) return DustCloudRenderer.sharedMaterial;
 
     const vertexShader = `
       precision mediump float;
@@ -109,7 +109,7 @@ export class CloudRenderer extends BaseRenderer {
       }
     `;
 
-    CloudRenderer.sharedMaterial = new THREE.ShaderMaterial({
+    DustCloudRenderer.sharedMaterial = new THREE.ShaderMaterial({
       transparent: true,
       depthWrite: false,
       blending: THREE.NormalBlending,
@@ -125,14 +125,14 @@ export class CloudRenderer extends BaseRenderer {
         uWind:      { value: new THREE.Vector2(0, 0) },
       }
     });
-    (CloudRenderer.sharedMaterial as any).toneMapped = true;
-    return CloudRenderer.sharedMaterial!;
+    (DustCloudRenderer.sharedMaterial as any).toneMapped = true;
+    return DustCloudRenderer.sharedMaterial!;
   }
 
   // ====== Public API ======
   render(object: TSceneObject): THREE.Object3D {
-    const cloudData: CloudData = object.data || {};
-            // CloudRenderer.render() викликано
+    const cloudData: DustCloudData = object.data || {};
+    // DustCloudRenderer.render() викликано
 
     const dustCloud = this.createCloudPoints(cloudData, object.coordinates);
 
@@ -176,9 +176,9 @@ export class CloudRenderer extends BaseRenderer {
 
     this.scene.remove(this.cloudGroup);
 
-    if (CloudRenderer.sharedMaterial) {
-      CloudRenderer.sharedMaterial.dispose();
-      CloudRenderer.sharedMaterial = null;
+    if (DustCloudRenderer.sharedMaterial) {
+      DustCloudRenderer.sharedMaterial.dispose();
+      DustCloudRenderer.sharedMaterial = null;
     }
 
     super.dispose();
@@ -187,7 +187,7 @@ export class CloudRenderer extends BaseRenderer {
   // Викликати раз за кадр
   updateAllClouds(): void {
     const t = this.clock.getElapsedTime();
-    const mat = CloudRenderer.sharedMaterial;
+    const mat = DustCloudRenderer.sharedMaterial;
     if (!mat) return;
 
     // глобальний час + одна синус/косинус на кадр (дешево)
@@ -221,7 +221,10 @@ export class CloudRenderer extends BaseRenderer {
   }
 
   // ====== Internal ======
-  private createCloudPoints(cloudData: CloudData, coordinates: { x: number; y: number; z: number }): THREE.Points {
+  private createCloudPoints(
+    cloudData: DustCloudData,
+    coordinates: { x: number; y: number; z: number }
+  ): THREE.Points {
     // Оптимізація: зменшуємо кількість частинок за замовчуванням
     const particleCount = cloudData.particleCount ?? 50; // було 100, тепер 50
     const radiusMax = cloudData.size ?? 20;     // радіус "гриба" по XZ

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RendererManager.ts
@@ -7,7 +7,6 @@ import { BiomassRenderer } from './BiomassRenderer'
 import { RoverRenderer } from './RoverRenderer'
 import { BuildingRenderer } from './BuildingRenderer'
 
-import { CloudRenderer } from './CloudRenderer'
 
 import { FireRenderer } from './FireRenderer'
 import { UiLogicBridge } from '@ui/logic/UiLogicBridge'
@@ -16,7 +15,6 @@ import { SmokeRenderer } from './SmokeRenderer'
 import { RoadRenderer } from './RoadRenderer'
 import { AuroraRenderer } from './environment/AuroraRenderer'
 import { SunRenderer } from './environment/SunRenderer'
-import { SkyCloudRenderer } from './environment/SkyCloudRenderer'
 // import { ExplosionRenderer } from './ExplosionRenderer'
 
 import type { GraphicsSettingsManager, ParticleQuality, ShadowQuality } from '@systems/graphics'
@@ -78,7 +76,7 @@ export class RendererManager {
             (buildingRenderer as any).setShadowMode?.(this.shadowMode);
         }
         this.registerRenderer('building', buildingRenderer); // Будівлі
-        // this.registerRenderer('cloud', new CloudRenderer(this.scene)); // Пилові хмари
+        // this.registerRenderer('cloud', new DustCloudRenderer(this.scene)); // Пилові хмари
         // this.registerRenderer('sky-cloud', new SkyCloudRenderer(this.scene)); // Небесні хмари
         const smokeRenderer = new SmokeRenderer(this.scene, this.renderer);
         if (this.particleQuality) {

--- a/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/TerrainRenderer.ts
@@ -26,7 +26,7 @@ export class TerrainRenderer {
   // Кеш списку текстур для блендів (щоб не перевизначати атрибути щоразу)
   private cachedTextureNames: string[] = [];
 
-  private shadowMode: ShadowQuality = 'pseudo';
+  private shadowMode: ShadowQuality = 'none';
 
   constructor(scene: THREE.Scene, terrainManager: TerrainManager, loadingManager?: THREE.LoadingManager) {
     this.scene = scene;

--- a/src/ui/screens/colony/scene/Scene3D/renderers/index.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/index.ts
@@ -2,7 +2,7 @@ export { BaseRenderer } from './BaseRenderer';
 export { RockRenderer } from './RockRenderer';
 export { BoulderRenderer } from './BoulderRenderer';
 export { RoverRenderer } from './RoverRenderer';
-export { CloudRenderer } from './CloudRenderer';
+export { DustCloudRenderer } from './DustCloudRenderer';
 export { SmokeRenderer } from './SmokeRenderer';
 export { FireRenderer } from './FireRenderer';
 export { ExplosionRenderer } from './ExplosionRenderer';

--- a/src/ui/screens/colony/scene/hooks/useSceneCore.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneCore.ts
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
+import type { AntialiasingMode } from '@systems/graphics';
 
-export function useSceneCore() {
+export function getPixelRatioForMode(mode: AntialiasingMode) {
+  const deviceRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  if (mode === 'msaa') {
+    return Math.min(1.5, deviceRatio);
+  }
+  return Math.min(1, deviceRatio);
+}
+
+export function useSceneCore(antialiasing: AntialiasingMode) {
   const scene = useMemo(() => {
     const s = new THREE.Scene();
     s.background = new THREE.Color('#5a4f2e'); // Початковий колір, буде оновлений динамічно
@@ -36,12 +45,16 @@ export function useSceneCore() {
   }, []);
 
   const renderer = useMemo(() => {
-    const r = new THREE.WebGLRenderer({ antialias: true });
+    const r = new THREE.WebGLRenderer({
+      antialias: antialiasing === 'msaa',
+      powerPreference: 'high-performance',
+    });
+    r.setPixelRatio(getPixelRatioForMode(antialiasing));
     r.setSize(window.innerWidth, window.innerHeight);
     r.shadowMap.enabled = false;
     r.shadowMap.type = THREE.PCFSoftShadowMap;
     return r;
-  }, []);
+  }, [antialiasing]);
 
   useEffect(() => {
     return () => {

--- a/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
+++ b/src/ui/screens/colony/settings/GraphicsSettingsModal.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { Modal } from '@ui/shared/Modal';
-import type { GraphicsSettingsState, ParticleQuality, ShadowQuality } from '@systems/graphics';
+import type {
+  GraphicsSettingsState,
+  ParticleQuality,
+  ShadowQuality,
+  AntialiasingMode,
+} from '@systems/graphics';
 import './GraphicsSettingsModal.css';
 
 interface GraphicsSettingsModalProps {
@@ -15,11 +20,6 @@ const SHADOW_OPTIONS: Array<{ value: ShadowQuality; label: string; description: 
     value: 'detailed',
     label: 'Детальні',
     description: 'Увімкнути динамічні тіні для будівель та біомаси.'
-  },
-  {
-    value: 'pseudo',
-    label: 'Псевдо-тіні',
-    description: 'Спрощені випечені плями без навантаження на тіньову карту.'
   },
   {
     value: 'none',
@@ -38,6 +38,23 @@ const PARTICLE_OPTIONS: Array<{ value: ParticleQuality; label: string; descripti
     value: 'low',
     label: 'Низька якість',
     description: 'Текстури 64×64, удвічі більші спрайти та зменшений спавн.'
+  }
+];
+
+const ANTIALIASING_OPTIONS: Array<{
+  value: AntialiasingMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'msaa',
+    label: 'MSAA',
+    description: 'Згладжування країв напряму в рендері. Витрачає більше ресурсів, але покращує якість.'
+  },
+  {
+    value: 'off',
+    label: 'Вимкнено',
+    description: 'Найвища продуктивність без згладжування країв.'
   }
 ];
 
@@ -64,6 +81,12 @@ export const GraphicsSettingsModal: React.FC<GraphicsSettingsModalProps> = ({
   const handleDustToggle = (value: boolean) => {
     if (value !== settings.droneDustTrails) {
       onChange({ droneDustTrails: value });
+    }
+  };
+
+  const handleAntialiasingChange = (value: AntialiasingMode) => {
+    if (value !== settings.antialiasing) {
+      onChange({ antialiasing: value });
     }
   };
 
@@ -135,6 +158,27 @@ export const GraphicsSettingsModal: React.FC<GraphicsSettingsModalProps> = ({
                     </span>
                   </div>
                 </label>
+              </div>
+            </section>
+
+            <section className="graphics-settings-section">
+              <h3 className="graphics-settings-section-title">Згладжування</h3>
+              <div className="graphics-settings-options">
+                {ANTIALIASING_OPTIONS.map(option => (
+                  <label key={option.value} className="graphics-settings-option">
+                    <input
+                      type="radio"
+                      name="antialiasing-mode"
+                      value={option.value}
+                      checked={settings.antialiasing === option.value}
+                      onChange={() => handleAntialiasingChange(option.value)}
+                    />
+                    <div className="graphics-settings-option-body">
+                      <span className="graphics-settings-option-label">{option.label}</span>
+                      <span className="graphics-settings-option-description">{option.description}</span>
+                    </div>
+                  </label>
+                ))}
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- gate all sky cloud logic behind a disabled-by-default flag so the environment no longer spawns them
- rename the dust cloud renderer for clarity and update graphics settings to drop the buggy pseudo shadow mode
- lower the default rendering cost by clamping pixel ratio, defaulting shadows to none, and exposing an MSAA toggle players can disable if they need extra FPS

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44265904083208abdfc40e3970e48