### PR TITLE
Fix scene sync when recreating renderer

### DIFF
--- a/src/ui/screens/colony/scene/hooks/useSceneSync.ts
+++ b/src/ui/screens/colony/scene/hooks/useSceneSync.ts
@@ -11,11 +11,17 @@ export function useSceneObjectSync(
   selectionRendererRef: MutableRefObject<SelectionRenderer | null>
 ) {
   const prevObjectsRef = useRef<Map<string, TSceneObject>>(new Map());
+  const lastRendererRef = useRef<RendererManager | null>(null);
 
   return useCallback(() => {
     const rm = rendererManagerRef.current;
     const map = mapLogicRef.current;
     if (!rm || !map) return;
+
+    if (rm !== lastRendererRef.current) {
+      prevObjectsRef.current.clear();
+      lastRendererRef.current = rm;
+    }
 
     const current = map.scene.getVisibleObjectsOptimized().map<TSceneObject>((obj) => ({
       tags: obj.tags,


### PR DESCRIPTION
## Summary
- reset cached scene object map whenever a new renderer manager instance is attached
- ensure objects are re-synced after toggling MSAA or other renderer recreations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44b2e6b68832090a23c08ff8e1cbc