### PR TITLE
Add construction effort scaling for buildings and roads

### DIFF
--- a/src/logic/modules/buildings/BuildingsManager.ts
+++ b/src/logic/modules/buildings/BuildingsManager.ts
@@ -368,8 +368,39 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
     }
   }
 
+  private resolveBuildingConstructionEffort(typeId: BuildingTypeId): number {
+    const type = this.buildingsDB.get(typeId);
+    const effort = type?.constructionEffort ?? 1;
+    return effort > 0 ? effort : 1;
+  }
+
+  private ensureBuildingConstructionEffort(instance: BuildingInstance): void {
+    if (instance.constructionEffort && instance.constructionEffort > 0) {
+      return;
+    }
+    instance.constructionEffort = this.resolveBuildingConstructionEffort(instance.typeId);
+  }
+
+  private resolveRoadSegmentConstructionEffort(length: number, roadType: RoadTypeData): number {
+    const perMeter = roadType.constructionEffortPerMeter ?? 1;
+    const validPerMeter = perMeter > 0 ? perMeter : 1;
+    const validLength = length > 0 ? length : 0.01;
+    return Math.max(0.01, validPerMeter * validLength);
+  }
+
+  private ensureRoadSegmentConstructionEffort(segment: RoadSegmentInstance, roadType: RoadTypeData): void {
+    if (segment.constructionEffort && segment.constructionEffort > 0) {
+      return;
+    }
+    segment.constructionEffort = this.resolveRoadSegmentConstructionEffort(segment.length ?? 1, roadType);
+  }
+
   public getInstance(instanceId: string): BuildingInstance | undefined {
-    return this.buildingInstances.get(instanceId);
+    const inst = this.buildingInstances.get(instanceId);
+    if (inst) {
+      this.ensureBuildingConstructionEffort(inst);
+    }
+    return inst;
   }
 
   private getBonusSourceId(typeId: BuildingTypeId): string {
@@ -413,6 +444,7 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
       built,
       position,
       constructionProgress: 0,
+      constructionEffort: this.resolveBuildingConstructionEffort(typeId),
       resourcesCollected: {},
     };
     this.buildingInstances.set(instanceId, inst);
@@ -460,6 +492,7 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
       built: false,
       position,
       constructionProgress: 0,
+      constructionEffort: this.resolveBuildingConstructionEffort(typeId),
       resourcesCollected: {},
     });
 
@@ -478,6 +511,9 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
     }
 
     const existing = this.getInstance(instanceId);
+    if (existing) {
+      this.ensureBuildingConstructionEffort(existing);
+    }
 
     // Create new instance built at level 1
     if (!existing) {
@@ -738,15 +774,18 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
 
     // Rehydrate instances and their scene projections
     data.buildingInstances.forEach(inst => {
-      this.buildingInstances.set(inst.id, { ...inst });
-      if (inst.position) {
-        this.generateBuilding(inst.typeId, inst.position, inst.level, inst.id);
+      const stored: BuildingInstance = { ...inst } as BuildingInstance;
+      this.ensureBuildingConstructionEffort(stored);
+      this.buildingInstances.set(inst.id, stored);
+      if (stored.position) {
+        this.generateBuilding(stored.typeId, stored.position, stored.level, stored.id);
       }
     });
 
     // Rehydrate roads if present
     if (data.roadInstances) {
       data.roadInstances.forEach(road => {
+        const roadType = this.roadsDB.get(road.typeId);
         // Автоматично маркуємо всі сегменти як збудовані якщо дорога вже збудована (фікс для старих збережень)
         if (road.built && road.segments && road.segments.some((s: any) => s.buildingState !== 'completed')) {
           road.segments = road.segments.map((s: any) => ({
@@ -758,7 +797,6 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
 
         // МІГРАЦІЯ: якщо це незбудована/запланована дорога та відсутні сегменти — відновлюємо сегменти як planned
         if (!road.built && (!road.segments || road.segments.length === 0) && Array.isArray(road.path) && road.path.length >= 2) {
-          const roadType = this.roadsDB.get(road.typeId);
           const perMeter = roadType?.cost ? roadType.cost(1) : {};
           const segs: any[] = [];
           for (let i = 1; i < road.path.length; i++) {
@@ -777,12 +815,17 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
               constructionProgress: 0.0,
               requiredResources: required,
               deliveredResources: {},
-              length
+              length,
+              constructionEffort: roadType ? this.resolveRoadSegmentConstructionEffort(length, roadType) : length
             });
           }
           (road as any).segments = segs;
           (road as any).plannedOnly = true;
           (road as any).resourcesDelivered = (road as any).resourcesDelivered || {};
+        }
+
+        if (roadType && road.segments) {
+          road.segments.forEach((segment: any) => this.ensureRoadSegmentConstructionEffort(segment, roadType));
         }
 
         this.roadInstances.set(road.id, { ...road });
@@ -1017,7 +1060,8 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
           constructionProgress: 0.0,
           requiredResources: required,
           deliveredResources: {},
-          length
+          length,
+          constructionEffort: roadType ? this.resolveRoadSegmentConstructionEffort(length, roadType) : length
         });
       }
       (roadInstance as any).segments = segs;
@@ -1324,7 +1368,7 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
       return;
     }
 
-    inst.constructionProgress = progress;
+    inst.constructionProgress = Math.min(1, Math.max(0, progress));
     
     // Тільки якщо передано - оновлюємо ресурси
     if (resourcesCollected !== undefined) {
@@ -1553,7 +1597,8 @@ export class BuildingsManager implements SaveLoadManager, IBuildingsManager {
         constructionProgress: 1.0,
         requiredResources: required,
         deliveredResources: delivered,
-        length
+        length,
+        constructionEffort: this.resolveRoadSegmentConstructionEffort(length, roadType)
       });
     }
 

--- a/src/logic/modules/buildings/buildings-db.ts
+++ b/src/logic/modules/buildings/buildings-db.ts
@@ -44,6 +44,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
       modelName: 'models/buildings/spaceship_v0.glb',
       hudOffsetY: 1,
     },
+    constructionEffort: 120,
     cost: storageCostFormula
   }],
 
@@ -89,6 +90,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
         chargeRate: 0.5,
         obstacleSize: 1.5,
     },
+    constructionEffort: 35,
     cost: chargingStationCostFormula
   }],
 
@@ -139,6 +141,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
       modelName: 'models/buildings/minimal_storage.glb',
       hudOffsetY: 1,
     },
+    constructionEffort: 20,
     cost: storageCostFormula
   }],
   
@@ -189,6 +192,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
       modelName: 'models/buildings/simple_storage.glb',
       hudOffsetY: 1,
     },
+    constructionEffort: 45,
     cost: storageCostFormula
   }],
   
@@ -233,6 +237,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
         chargeRate: 0.5,
         obstacleSize: 1.5,
     },
+    constructionEffort: 45,
     cost: chargingStationCostFormula
   }],
 
@@ -266,6 +271,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
     data: {
         obstacleSize: 1.5,
     },
+    constructionEffort: 25,
     cost: (level: number) => ({
       stone: 20 + (level - 1) * 50,
       ore: 10 + (level - 1) * 30,
@@ -325,6 +331,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
       }
     },
     isConstuctuble: true,
+    constructionEffort: 55,
     cost: bioGeneratorCostFormula
   }],
 
@@ -380,6 +387,7 @@ export const BUILDINGS_DB: Map<BuildingTypeId, BuildingTypeData> = new Map([
       }
     },
     isConstuctuble: true,
+    constructionEffort: 60,
     cost: bioIncubatorCostFormula
   }]
 ]);
@@ -425,6 +433,7 @@ export const ROADS_DB: Map<RoadTypeId, RoadTypeData> = new Map([
     width: 1.0,
     speedBonus: 1.5,
     cost: basicRoadCostFormula,
+    constructionEffortPerMeter: 6,
     isSegmented: true, // будується сегментами
     ui: {
       color: '#8B4513', // коричневий
@@ -443,6 +452,7 @@ export const ROADS_DB: Map<RoadTypeId, RoadTypeData> = new Map([
     width: 1.5,
     speedBonus: 2.0,
     cost: reinforcedRoadCostFormula,
+    constructionEffortPerMeter: 9,
     isSegmented: true, // будується сегментами
     ui: {
       color: '#696969', // темно-сірий

--- a/src/logic/modules/buildings/buildings.types.ts
+++ b/src/logic/modules/buildings/buildings.types.ts
@@ -35,6 +35,7 @@ export interface RoadTypeData {
   width: number;         // ширина дороги в метрах
   speedBonus: number;    // множник швидкості (1.5 = +50%)
   cost: CostFormula;     // вартість за метр
+  constructionEffortPerMeter: number; // зусилля будівництва на метр
   isSegmented: boolean;  // чи будується сегментами (дороги, ЛЕПи, тощо)
   ui: {
     color?: string;      // колір для відображення
@@ -57,6 +58,7 @@ export interface RoadSegmentInstance {
   endPoint: Vector3;             // кінцева точка сегмента
   buildingState: RoadSegmentState; // стан будівництва
   constructionProgress: number;   // прогрес будівництва (0-1)
+  constructionEffort?: number;    // загальний ефорт необхідний для сегмента
   requiredResources: Record<string, number>; // потрібні ресурси
   deliveredResources: Record<string, number>; // доставлені ресурси
   length: number;                // довжина сегмента в метрах
@@ -104,6 +106,7 @@ export interface BuildingTypeData {
   requirements?: Requirement[]; // Реквайрменти для будівництва
   ui: BuildingUI;
   cost: CostFormula;
+  constructionEffort: number; // загальний ефорт для будівництва (в секундах при base speed 1)
   maxLevel: number;
   name: string;
   description: string;
@@ -123,6 +126,7 @@ export interface BuildingInstance {
   position?: Vector3;
   // Нові поля для планування будівництва
   constructionProgress?: number; // Прогрес будівництва (0-1)
+  constructionEffort?: number;   // Загальний ефорт будівництва (для перерахунку швидкості)
   resourcesCollected?: Record<string, number>; // Зібрані ресурси для будівництва
   
   // НОВЕ: Внутрішні склади будівель

--- a/src/logic/systems/commands/executors/BuildExecutor.ts
+++ b/src/logic/systems/commands/executors/BuildExecutor.ts
@@ -93,10 +93,14 @@ export class BuildExecutor extends CommandExecutor {
         }
 
         const buildSpeed = object.data.buildSpeed || 0.5; // прогрес будівництва в секунду (50% за секунду за замовчуванням)
-        const progressIncrement = buildSpeed * deltaTime;
+        const buildingType = buildingsManager.getBuildingType?.(buildingInstance.typeId);
+        const effort = buildingInstance.constructionEffort ?? buildingType?.constructionEffort ?? 1;
+        const normalizedEffort = effort > 0 ? effort : 1;
+        const progressIncrement = (buildSpeed * deltaTime) / normalizedEffort;
 
         // Оновлюємо прогрес будівництва
-        const newProgress = Math.min(1.0, buildingInstance.constructionProgress + progressIncrement);
+        const currentProgress = buildingInstance.constructionProgress ?? 0;
+        const newProgress = Math.min(1.0, currentProgress + progressIncrement);
         
         // Використовуємо метод BuildingsManager для оновлення прогресу
         buildingsManager.updateConstructionProgress(buildingId, newProgress);

--- a/src/logic/systems/commands/executors/road/BuildRoadExecutor.ts
+++ b/src/logic/systems/commands/executors/road/BuildRoadExecutor.ts
@@ -60,8 +60,10 @@ export class BuildRoadExecutor extends CommandExecutor {
     this.lastTime = now;
 
     const buildSpeed = (this.context.scene.getObjectById(this.context.objectId)?.data?.buildSpeed ?? 0.5) as number;
+    const effort = seg.constructionEffort ?? (seg.length && seg.length > 0 ? seg.length : 1);
+    const normalizedEffort = effort > 0 ? effort : 1;
     const oldProgress = seg.constructionProgress || 0;
-    const newProgress = Math.min(1.0, oldProgress + buildSpeed * dt);
+    const newProgress = Math.min(1.0, oldProgress + (buildSpeed * dt) / normalizedEffort);
     
     seg.constructionProgress = newProgress;
     

--- a/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
+++ b/src/ui/screens/colony/scene/Scene3D/renderers/RoadRenderer.ts
@@ -719,6 +719,8 @@ export class RoadRenderer extends BaseRenderer {
     const deliveredTotals: Record<string, number> = {};
     let segmentsBuiltFromStates = 0;
     let segmentsTotal = segmentStates.length;
+    let totalEffort = 0;
+    let completedEffort = 0;
 
     for (const state of segmentStates) {
       if (!state) continue;
@@ -728,6 +730,16 @@ export class RoadRenderer extends BaseRenderer {
       if (builtFlag || progressFlag) {
         segmentsBuiltFromStates += 1;
       }
+
+      const rawEffort = Number((state as any).constructionEffort ?? (state as any).length ?? 0);
+      const segmentEffort = rawEffort > 0 ? rawEffort : Math.max(Number((state as any).length) || 0, 1);
+      totalEffort += segmentEffort;
+      const segmentProgress = builtFlag
+        ? 1
+        : typeof state.constructionProgress === 'number'
+          ? THREE.MathUtils.clamp(state.constructionProgress, 0, 1)
+          : 0;
+      completedEffort += segmentEffort * segmentProgress;
 
       const required = state.requiredResources ?? {};
       for (const [resource, amount] of Object.entries(required)) {
@@ -795,7 +807,18 @@ export class RoadRenderer extends BaseRenderer {
       }
     }
 
-    const progress = totalRequired > 0 ? Math.min(1, totalCollected / totalRequired) : 0;
+    const resourceProgress = totalRequired > 0 ? Math.min(1, totalCollected / totalRequired) : 0;
+
+    let progress: number;
+    if (totalEffort > 0) {
+      progress = Math.min(1, completedEffort / totalEffort);
+    } else if (aggregates) {
+      const totalSegs = Math.max(segmentsTotal, aggregates.totalSegments ?? 0);
+      const builtSegs = Math.max(segmentsBuiltFromStates, aggregates.builtSegments ?? 0);
+      progress = totalSegs > 0 ? Math.min(1, builtSegs / totalSegs) : 0;
+    } else {
+      progress = resourceProgress;
+    }
 
     return {
       required,


### PR DESCRIPTION
## Summary
- add constructionEffort and constructionEffortPerMeter metadata to building and road databases
- propagate effort defaults through BuildingsManager so instances and road segments track construction effort for progress calculations
- scale building and road construction progress by effort and show aggregate build progress in the road HUD instead of resource delivery

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4584abff88320b44b24f26939e47d